### PR TITLE
Let Docker automatically build config manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
+FROM golang:latest
+WORKDIR /go/src/app
+COPY . .
+ENV CGO_ENABLED=0
+RUN ["go", "build", "-o", "config_manager", "main.go"]
+
 FROM registry.redhat.io/ubi8/go-toolset
 MAINTAINER jassteph@redhat.com
-
-COPY ./config_manager ./config_manager
 COPY ./db/migrations ./db/migrations
-
+COPY --from=0 /go/src/app/config_manager .
 ENTRYPOINT ["./config_manager"]


### PR DESCRIPTION
Rewrite the Dockerfile to make use of multi-stage builds [1]. Let the
first stage build the `config_manager` binary, and let the second stage
copy that binary and its dependencies (like migration scripts) to a UBI.

The primary benefits of this change are:

*   Build consistency. All developers and build systems will compile the
    application using the same version of Go.
*   Build streamlining. Building an image with config manager has been
    shortened from `make build && make build-image` to `make
    build-image`.

    The `build` make target could be removed, but was left in place to
    make this PR more targeted.