### PR TITLE
Quote port numbers in Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   kafka:
     image: confluentinc/cp-kafka
     ports:
-      - 29092:29092
+      - "29092:29092"
     depends_on:
        - zookeeper
     environment:
@@ -30,11 +30,11 @@ services:
       POSTGRES_USER: insights
       POSTGRES_DB: config-manager
     ports:
-      - 5432:5432
+      - "5432:5432"
   config-manager:
     image: config-manager-poc
     ports:
-      - 8081:8081
+      - "8081:8081"
     depends_on:
       - kafka
       - db


### PR DESCRIPTION
From the spec [1]:

> `HOST:CONTAINER` SHOULD always be specified as a (quoted) string, to
> avoid conflicts with yaml base-60 float.

[1] https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports