### PR TITLE
Bump Compose file version number

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 #docker compose for kafka, zookeeper, postgres, and config-manager
 
-version: "3"
+version: "3.8"
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper


### PR DESCRIPTION
From the Docker documentation [1]:

> When specifying the Compose file version to use, make sure to specify
> both the major and minor numbers. If no minor version is given, 0 is
> used by default and not the latest minor version.

In other words, the following version numbers are equivalent:

* `3`
* `3.0`

Using this old of a version number is probably not what is intended, and
there are downsides to using such an old compose spec version:

> Several things differ depending on which version you use:
>
> * The structure and permitted configuration keys
> * The minimum Docker Engine version you must be running
> * Compose’s behaviour with regards to networking

[1] https://docs.docker.com/compose/compose-file/compose-versioning/#versioning