### PR TITLE
Use Compose "build support" feature

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - 5432:5432
   config-manager:
     image: config-manager-poc
+    build: .
     ports:
       - 8081:8081
     depends_on:


### PR DESCRIPTION
If `docker-compose up` is executed and one of the following is true for
a service:

* The service sets `image` but that image isn't present in any registries,
  and the service sets `build`.
* The service doesn't set `image`, but does set `build`.

Then Compose will build the referenced image and add it to the local
registry.

This behavior is defined as part of the Compose specification's "build
support" feature. This feature is an optional part of the Compose
specification, meaning that not all Compose implementations support it.
Anecdotally, if the well-known Docker and Docker Compose applications
are used, then it works out of the box. For more on the Compose
specification's "build support" feature, see:
https://github.com/compose-spec/compose-spec/blob/master/build.md

The benefit of this change is that spinning up containers is more
streamlined:

```bash
make build-image && docker-compose up # old
docker-compose up # new
```

If one wishes to re-build an image, e.g. after editing source code, the
simplest solution is to execute `docker-compose up --build`. Other
solutions are available, but beyond the scope of this commit message.