### PR TITLE
Use build stage name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN ["go", "build", "-o", "config_manager", "main.go"]
 FROM registry.redhat.io/ubi8-minimal
 MAINTAINER jassteph@redhat.com
 COPY ./db/migrations ./db/migrations
-COPY --from=0 /go/src/app/config_manager .
+COPY --from=builder /go/src/app/config_manager .
 ENTRYPOINT ["./config_manager"]


### PR DESCRIPTION
In multi-stage builds:

> By default, the stages are not named, and you refer to them by their
> integer number, starting with 0 for the first FROM instruction.
> However, you can name your stages, by adding an AS <NAME> to the FROM
> instruction. [...] This means that even if the instructions in your
> Dockerfile are re-ordered later, the COPY doesn’t break.

See:
https://docs.docker.com/develop/develop-images/multistage-build/#name-your-build-stages