### PR TITLE
Change restart policy to on-failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - KAFKA_MAX_REQUEST_SIZE=1048576
   db:
     image: postgres
-    restart: always
+    restart: on-failure
     environment:
       POSTGRES_PASSWORD: insights
       POSTGRES_USER: insights


### PR DESCRIPTION
The "always" restart policy "always restarts the container until its
removal." This means that that one could explicitly stop a container and
then restart one's computer, and the container would still be running
after the reboot.

Given that the Compose file in this repository appears to be used for
development and QA purposes, this is a bit painful. I'd rather not have
dev or qa tooling making my computer do things even after reboot.