### PR TITLE
Adding cloud-connector integration

### DIFF
--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -101,14 +101,14 @@ func (cmc *ConfigManagerController) UpdateStates(ctx echo.Context) error {
 
 	// This should happen before the call to update state. Perhaps as another api call that responds with a list
 	// of clients to be passed into this endpoint - preflight check
-	clients, err := cmc.ConfigManagerService.GetClients(id.Identity.AccountNumber)
+	clients, err := cmc.ConfigManagerService.GetConnectorClients(ctx.Request().Context(), id.Identity.AccountNumber)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	// TODO: Update ApplyState to return proper response data (dispatcher response code + id per client)
 
-	results, err := cmc.ConfigManagerService.ApplyState(ctx.Request().Context(), acc, clients.Clients)
+	results, err := cmc.ConfigManagerService.ApplyState(ctx.Request().Context(), acc, clients)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -64,17 +64,22 @@ func Get() *viper.Viper {
 
 	options.SetDefault("Dispatcher_Host", "http://playbook-dispatcher-api.playbook-dispatcher-ci.svc.cluster.local:8000")
 	options.SetDefault("Dispatcher_PSK", "")
-	options.SetDefault("Dispatcher_Batch_Size", 50) //TODO change string format on all other config vars
+	options.SetDefault("Dispatcher_Batch_Size", 50)
 	options.SetDefault("Dispatcher_Timeout", 10)
 	options.SetDefault("Dispatcher_Impl", "impl")
 	options.SetDefault("Playbook_URL", "https://ci.cloud.redhat.com/api/config-manager/v1/states/%s/playbook")
+
+	options.SetDefault("Cloud_Connector_Host", "http://cloud-connector.connector-ci.svc.cluster.local:8080")
+	options.SetDefault("Cloud_Connector_Client_ID", "config-manager")
+	options.SetDefault("Cloud_Connector_PSK", "")
+	options.SetDefault("Cloud_Connector_Timeout", 10)
+	options.SetDefault("Cloud_Connector_Impl", "impl")
 
 	options.SetDefault("Playbook_Path", "./playbooks/")
 
 	options.SetDefault("Service_Config", `{
 		"insights": "enabled",
 		"compliance_openscap": "enabled",
-		"resource_optimization": "enabled",
 		"remediations": "enabled"
 	}`)
 

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -59,6 +59,12 @@ objects:
               name: psk-playbook-dispatcher
         - name: CM_DISPATCHER_HOST
           value: ${CM_DISPATCHER_HOST}
+        - name: CM_DISPATCHER_IMPL
+          value: ${CM_DISPATCHER_IMPL}
+        - name: CM_CLOUD_CONNECTOR_HOST
+          value: ${CM_CLOUD_CONNECTOR_HOST}
+        - name: CM_CLOUD_CONNECTOR_IMPL
+          value: ${CM_CLOUD_CONNECTOR_IMPL}
       resources:
         limits:
           cpu: ${CPU_LIMIT}
@@ -75,13 +81,23 @@ parameters:
 - description : ClowdEnvironment name
   name: ENV_NAME
   required: true
+
 - name: LOG_LEVEL
   value: INFO
 - name: CPU_LIMIT
   value: 500m
 - name: MEMORY_LIMIT
   value: 512Mi
+
 - name: REPLICAS
   value: "2"
+
 - name: CM_DISPATCHER_HOST
   required: true
+- name: CM_DISPATCHER_IMPL
+  value: impl
+
+- name: CM_CLOUD_CONNECTOR_HOST
+  value: mock
+- name: CM_CLOUD_CONNECTOR_IMPL
+  value: mock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,3 +42,4 @@ services:
     environment:
       - CM_DB_HOST=db
       - CM_DISPATCHER_IMPL=mock
+      - CM_CLOUD_CONNECTOR_IMPL=mock

--- a/domain/cloud_connector.go
+++ b/domain/cloud_connector.go
@@ -1,0 +1,11 @@
+package domain
+
+import "context"
+
+type CloudConnectorConnections struct {
+	Connections []string `json:"connections"`
+}
+
+type CloudConnectorClient interface {
+	GetConnections(ctx context.Context, accountID string) ([]string, error)
+}

--- a/infrastructure/persistence/cloud_connector_repository.go
+++ b/infrastructure/persistence/cloud_connector_repository.go
@@ -1,0 +1,50 @@
+package persistence
+
+import (
+	"config-manager/domain"
+	"config-manager/utils"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	headerCloudConnectorClientID = "x-rh-receptor-controller-client-id"
+	headerCloudConnectorAccount  = "x-rh-receptor-controller-account"
+	headerCloudConnectorPSK      = "x-rh-receptor-controller-psk"
+)
+
+type CloudConnectorClient struct {
+	CloudConnectorHost     string
+	CloudConnectorClientID string
+	CloudConnectorPSK      string
+	Client                 utils.HTTPClient
+}
+
+func (c *CloudConnectorClient) GetConnections(
+	ctx context.Context,
+	accountID string,
+) ([]string, error) {
+	fmt.Println("Sending request to cloud connector")
+
+	req, err := http.NewRequestWithContext(ctx, "GET", c.CloudConnectorHost+"/api/cloud-connector/v1/connection/"+accountID, nil)
+	if err != nil {
+		fmt.Println("Error constructing request to cloud-connector: ", err)
+		return nil, err
+	}
+	req.Header.Set(headerCloudConnectorClientID, c.CloudConnectorClientID)
+	req.Header.Set(headerCloudConnectorPSK, c.CloudConnectorPSK)
+	req.Header.Set(headerCloudConnectorAccount, accountID)
+
+	res, err := c.Client.Do(req)
+	if err != nil {
+		fmt.Println("Error during request to cloud-connector: ", err)
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var cloudConnectorRes domain.CloudConnectorConnections
+	err = json.NewDecoder(res.Body).Decode(&cloudConnectorRes)
+	return cloudConnectorRes.Connections, err
+}

--- a/infrastructure/persistence/cloud_connector_repository_test.go
+++ b/infrastructure/persistence/cloud_connector_repository_test.go
@@ -1,0 +1,49 @@
+package persistence_test
+
+import (
+	"config-manager/infrastructure/persistence"
+	"config-manager/utils"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConnectionsSuccess(t *testing.T) {
+	response := `{
+		"connections": ["3d711f8b-77d0-4ed5-a5b5-1d282bf930c7", "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4"]
+	}`
+
+	connector := &persistence.CloudConnectorClient{
+		CloudConnectorHost:     "test",
+		CloudConnectorClientID: "test",
+		CloudConnectorPSK:      "test",
+		Client:                 utils.SetupMockHTTPClient(response, 200),
+	}
+
+	results, err := connector.GetConnections(context.Background(), "0000001")
+
+	assert.Nil(t, err)
+	assert.Equal(t, len(results), 2, "there should be two connections returned")
+
+	assert.Equal(t, results[0], "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7", "the id from the response should be included")
+	assert.Equal(t, results[1], "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4", "The id from the response should be included")
+}
+
+func TestGetConnectionsAccountNotFound(t *testing.T) {
+	response := `{
+		"connections": []
+	}`
+
+	connector := &persistence.CloudConnectorClient{
+		CloudConnectorHost:     "test",
+		CloudConnectorClientID: "test",
+		CloudConnectorPSK:      "test",
+		Client:                 utils.SetupMockHTTPClient(response, 200),
+	}
+
+	results, err := connector.GetConnections(context.Background(), "0000001")
+
+	assert.Nil(t, err)
+	assert.Equal(t, len(results), 0, "results should exist, but there should be no connections")
+}

--- a/infrastructure/persistence/dispatcher_repository_test.go
+++ b/infrastructure/persistence/dispatcher_repository_test.go
@@ -3,6 +3,7 @@ package persistence_test
 import (
 	"config-manager/domain"
 	"config-manager/infrastructure/persistence"
+	"config-manager/utils"
 	"context"
 	"testing"
 
@@ -37,7 +38,7 @@ func TestDispatchSuccess(t *testing.T) {
 	dispatcher := &persistence.DispatcherClient{
 		DispatcherHost: "test",
 		DispatcherPSK:  "test",
-		Client:         persistence.SetupMockDispatcherClient(response),
+		Client:         utils.SetupMockHTTPClient(response, 207),
 	}
 
 	results, err := dispatcher.Dispatch(context.Background(), inputs)
@@ -61,7 +62,7 @@ func TestDispatchNotFound(t *testing.T) {
 	dispatcher := &persistence.DispatcherClient{
 		DispatcherHost: "test",
 		DispatcherPSK:  "test",
-		Client:         persistence.SetupMockDispatcherClient(response),
+		Client:         utils.SetupMockHTTPClient(response, 207),
 	}
 
 	results, err := dispatcher.Dispatch(context.Background(), inputs)

--- a/utils/http_client.go
+++ b/utils/http_client.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+)
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type MockDoType func(req *http.Request) (*http.Response, error)
+
+type ClientMock struct {
+	MockDo MockDoType
+}
+
+func (m *ClientMock) Do(req *http.Request) (*http.Response, error) {
+	return m.MockDo(req)
+}
+
+func SetupMockHTTPClient(expectedResponse string, status int) *ClientMock {
+	r := ioutil.NopCloser(bytes.NewReader([]byte(expectedResponse)))
+
+	client := &ClientMock{
+		MockDo: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: status,
+				Body:       r,
+			}, nil
+		},
+	}
+
+	return client
+}


### PR DESCRIPTION
This PR allows config-manager to retrieve a list of connected clients for the requesting account from the cloud-connector service. Eventually these clients will be retrieved from HBI, but in the meantime we can use cloud-connector to get the currently connected clients for dispatching work to the playbook-dispatcher. 

Another PR will follow that includes the inventory connector and a refactor to allow for easier swapping of the "client/host retriever". 