### PR TITLE
Inventory consumer

### DIFF
--- a/application/config_manager_service.mock.go
+++ b/application/config_manager_service.mock.go
@@ -1,0 +1,22 @@
+package application
+
+import (
+	"config-manager/domain"
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type ConfigManagerServiceMock struct {
+	mock.Mock
+}
+
+func (m *ConfigManagerServiceMock) GetAccountState(id string) (*domain.AccountState, error) {
+	args := m.Called(id)
+	return args.Get(0).(*domain.AccountState), args.Error(1)
+}
+
+func (m *ConfigManagerServiceMock) ApplyState(ctx context.Context, acc *domain.AccountState, clients []string) ([]domain.DispatcherResponse, error) {
+	args := m.Called(ctx, acc, clients)
+	return args.Get(0).([]domain.DispatcherResponse), args.Error(1)
+}

--- a/domain/config_manager.go
+++ b/domain/config_manager.go
@@ -1,0 +1,8 @@
+package domain
+
+import "context"
+
+type ConfigManagerInterface interface {
+	GetAccountState(id string) (*AccountState, error)
+	ApplyState(ctx context.Context, acc *AccountState, clients []string) ([]DispatcherResponse, error)
+}

--- a/domain/message/inventory.go
+++ b/domain/message/inventory.go
@@ -1,0 +1,18 @@
+package message
+
+type InventoryEvent struct {
+	Type string        `json:"type"`
+	Host InventoryHost `json:"host"`
+}
+
+type InventoryHost struct {
+	ID            string            `json:"id"`
+	Account       string            `json:"account"`
+	Reporter      string            `json:"reporter"`
+	SystemProfile HostSystemProfile `json:"system_profile"`
+}
+
+type HostSystemProfile struct {
+	RHCID    string `json:"rhc_client_id"`
+	RHCState string `json:"rhc_config_state"`
+}

--- a/infrastructure/kafka/kafka.go
+++ b/infrastructure/kafka/kafka.go
@@ -36,3 +36,13 @@ func NewConsumerEventLoop(
 		}
 	}
 }
+
+func GetHeader(msg kafka.Message, key string) (string, error) {
+	for _, value := range msg.Headers {
+		if value.Key == key {
+			return string(value.Value), nil
+		}
+	}
+
+	return "", fmt.Errorf("Header not found: %s", key)
+}

--- a/inventory-consumer/handler.go
+++ b/inventory-consumer/handler.go
@@ -1,15 +1,51 @@
 package inventoryconsumer
 
 import (
+	"config-manager/application"
+	"config-manager/domain/message"
 	"context"
+	"encoding/json"
 	"fmt"
 
 	kafka "github.com/segmentio/kafka-go"
 )
 
 type handler struct {
+	ConfigManagerService *application.ConfigManagerService
 }
 
 func (this *handler) onMessage(ctx context.Context, msg kafka.Message) {
-	fmt.Println("Message: ", msg.Value)
+	value := &message.InventoryEvent{}
+
+	if err := json.Unmarshal(msg.Value, &value); err != nil {
+		fmt.Println("Couldn't unmarshal inventory event: ", err)
+		return
+	}
+
+	fmt.Printf("Unmarshalled Message: %+v\n", value)
+
+	if value.Host.SystemProfile.RHCID != "" {
+		accState, err := this.ConfigManagerService.GetAccountState(value.Host.Account)
+		if err != nil {
+			fmt.Println("Error retrieving state for account: ", value.Host.Account)
+		}
+
+		clientSlice := []string{value.Host.SystemProfile.RHCID}
+
+		switch value.Type {
+		case "created":
+			responses, err := this.ConfigManagerService.ApplyState(ctx, accState, clientSlice)
+			if err != nil {
+				fmt.Println("Error applying state: ", err)
+			}
+			fmt.Println("Message sent to the dispatcher. Results: ", responses)
+		case "updated":
+			// TODO: Config-manager needs to update rhc_config_state in inventory before this can be implemented
+			// Check rhc_config_state: if not equal to accState.StateID then apply new state
+			fmt.Println("Existing RHC client.. checking state")
+		default:
+			// type "deleted". Remove host reference from state record
+			fmt.Println("RHC client removed from inventory")
+		}
+	}
 }

--- a/inventory-consumer/handler_test.go
+++ b/inventory-consumer/handler_test.go
@@ -10,9 +10,6 @@ import (
 )
 
 func newKafkaMessage(t *testing.T, headers []kafka.Header, data []byte) kafka.Message {
-	// value, err := json.Marshal(data)
-	// assert.Nil(t, err)
-
 	return kafka.Message{
 		Headers: headers,
 		Value:   data,

--- a/inventory-consumer/handler_test.go
+++ b/inventory-consumer/handler_test.go
@@ -1,0 +1,147 @@
+package inventoryconsumer
+
+import (
+	"config-manager/application"
+	"config-manager/domain"
+	"context"
+	"testing"
+
+	"github.com/segmentio/kafka-go"
+)
+
+func newKafkaMessage(t *testing.T, headers []kafka.Header, data []byte) kafka.Message {
+	// value, err := json.Marshal(data)
+	// assert.Nil(t, err)
+
+	return kafka.Message{
+		Headers: headers,
+		Value:   data,
+	}
+}
+
+func newKafkaHeaders(eventType string) []kafka.Header {
+	var headers []kafka.Header
+
+	headers = append(headers, kafka.Header{
+		Key:   "event_type",
+		Value: []byte(eventType),
+	})
+
+	return headers
+}
+
+var tests = []struct {
+	name       string
+	eventType  string
+	data       []byte
+	account    string
+	validEvent bool
+}{
+	{
+		"cloud-connector event: created",
+		"created",
+		[]byte(`{
+			"type": "created",
+			"host": {
+				"id": "1234",
+				"account": "0000001",
+				"reporter": "cloud-connector",
+				"system_profile": {
+					"rhc_client_id": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
+					"rhc_config_state": "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4"
+				}
+			}
+		}`),
+		"0000001",
+		true,
+	},
+	{
+		"cloud-connector event: updated",
+		"updated",
+		[]byte(`{
+			"type": "updated",
+			"host": {
+				"id": "1234",
+				"account": "0000002",
+				"reporter": "cloud-connector",
+				"system_profile": {
+					"rhc_client_id": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
+					"rhc_config_state": "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4"
+				}
+			}
+		}`),
+		"0000002",
+		true,
+	},
+	{
+		"cloud-connector event: delete",
+		"delete",
+		[]byte(`{
+			"type": "delete",
+			"id": "1234",
+			"account": "0000001"
+		}`),
+		"0000001",
+		false,
+	},
+	{
+		"other reporter event: updated",
+		"updated",
+		[]byte(`{
+			"type": "updated",
+			"host": {
+				"id": "1234",
+				"account": "0000001",
+				"reporter": "other",
+				"system_profile": {
+					"rhc_client_id": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
+					"rhc_config_state": "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4"
+				}
+			}
+		}`),
+		"0000001",
+		false,
+	},
+}
+
+func TestInventoryMessageHandler(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cmServiceMock = new(application.ConfigManagerServiceMock)
+
+			cmServiceMock.On(
+				"GetAccountState",
+				tt.account,
+			).Return(&domain.AccountState{AccountID: tt.account}, nil)
+
+			cmServiceMock.On(
+				"ApplyState",
+				ctx,
+				&domain.AccountState{AccountID: tt.account},
+				[]string{"3d711f8b-77d0-4ed5-a5b5-1d282bf930c7"},
+			).Return([]domain.DispatcherResponse{}, nil)
+
+			handler := &handler{
+				ConfigManagerService: cmServiceMock,
+			}
+
+			handler.onMessage(ctx, newKafkaMessage(t, newKafkaHeaders(tt.eventType), tt.data))
+
+			if tt.validEvent {
+				cmServiceMock.AssertCalled(t, "GetAccountState", tt.account)
+				cmServiceMock.AssertCalled(
+					t,
+					"ApplyState",
+					ctx,
+					&domain.AccountState{AccountID: tt.account},
+					[]string{"3d711f8b-77d0-4ed5-a5b5-1d282bf930c7"},
+				)
+			} else {
+				cmServiceMock.AssertNotCalled(t, "GetAccountState")
+				cmServiceMock.AssertNotCalled(t, "ApplyState")
+			}
+		})
+	}
+}

--- a/inventory-consumer/main.go
+++ b/inventory-consumer/main.go
@@ -1,6 +1,7 @@
 package inventoryconsumer
 
 import (
+	"config-manager/infrastructure"
 	"config-manager/infrastructure/kafka"
 	"context"
 
@@ -14,7 +15,11 @@ func Start(
 ) {
 	consumer := kafka.NewConsumer(cfg, cfg.GetString("Kafka_Inventory_Topic"))
 
-	handler := &handler{}
+	container := infrastructure.Container{Config: cfg}
+
+	cmService := container.CMService()
+
+	handler := &handler{ConfigManagerService: cmService}
 
 	start := kafka.NewConsumerEventLoop(ctx, consumer, handler.onMessage, errors)
 


### PR DESCRIPTION
This is a bit of a mess, but this PR enables config-manager to apply the account's current service enablement config to any newly connected clients that are reported to inventory via cloud-connector. Currently a playbook will be supplied to a host if it has been either recently created or updated.

Once config-manager is updating hosts in inventory we can utilize the rhc_config_state system-profile field and only supply a playbook when a client is recently created or out of date (to avoid unnecessary work on simple disconnects). 

A minimal mock for the ConfigManagerService was added for testing purposes, and will be expanded on as needed.