### PR TITLE
Checking existence of play before adding it to the playbook

### DIFF
--- a/application/generator.go
+++ b/application/generator.go
@@ -42,8 +42,10 @@ func (g *Generator) GeneratePlaybook(state domain.StateMap) (string, error) {
 			return "", err
 		}
 
-		play := g.Templates[key]
-		playbook = append(playbook, formatPlay(play)...)
+		play, exists := g.Templates[key]
+		if exists {
+			playbook = append(playbook, formatPlay(play)...)
+		}
 	}
 
 	return string(playbook), err

--- a/application/generator_test.go
+++ b/application/generator_test.go
@@ -82,3 +82,42 @@ func TestGenerateAllDisabled(t *testing.T) {
 		t.Errorf("Received playbook did not contain expected plays: %s", pb)
 	}
 }
+
+func TestGenerateWhenServiceDoesNotHavePlay(t *testing.T) {
+	templates := utils.FilesIntoMap("../playbooks/test/", "*.yml")
+
+	pbg := &Generator{
+		Templates: templates,
+	}
+
+	state := domain.StateMap{
+		"test1":              "disabled",
+		"test2":              "disabled",
+		"serviceWithoutPlay": "disabled",
+	}
+
+	pb, err := pbg.GeneratePlaybook(state)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedPlay1 := `
+- name: Test 1
+  hosts: localhost
+  tasks:
+    - name: Print 1 removed
+      debug:
+        msg: "1 removed"`
+
+	expectedPlay2 := `
+- name: Test 2
+  hosts: localhost
+  tasks:
+    - name: Print 2 removed
+      debug:
+        msg: "2 removed"`
+
+	if !strings.Contains(pb, expectedPlay1) || !strings.Contains(pb, expectedPlay2) {
+		t.Errorf("Received playbook did not contain expected plays: %s", pb)
+	}
+}


### PR DESCRIPTION
This isn't strictly necessary as it works fine without the check, but it does make it clearer that the service enablement state can include services that don't require playbooks. For example remediations does not get set up or removed via a playbook, but an org admin can disable playbook execution via the service enablement dashboard. 

The generator tests are poorly done - they need to be updated 