### PR TITLE
Adding playbook content to json response as string instead of interface

### DIFF
--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -152,5 +152,5 @@ func (cmc *ConfigManagerController) GetPlaybookById(ctx echo.Context, stateID St
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	return ctx.JSON(http.StatusOK, playbook)
+	return ctx.String(http.StatusOK, playbook)
 }


### PR DESCRIPTION
Quick fix to enable the rhc client to run the playbook included in the http response directly