### PR TITLE
Adding pagination metadata to /states response. Adding preview endpoint

### DIFF
--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -154,3 +154,28 @@ func (cmc *ConfigManagerController) GetPlaybookById(ctx echo.Context, stateID St
 
 	return ctx.String(http.StatusOK, playbook)
 }
+
+// GetPlaybookPreview generates and returns a playbook preview to a requesting client
+// (GET /states/preview)
+func (cmc *ConfigManagerController) GetPlaybookPreview(ctx echo.Context) error {
+	id := identity.Get(ctx.Request().Context())
+	fmt.Printf("Getting playbook preview for account: %s\n", id.Identity.AccountNumber)
+
+	payload := &domain.StateMap{}
+	bytes, err := ioutil.ReadAll(ctx.Request().Body)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	err = json.Unmarshal(bytes, payload)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	playbook, err := cmc.ConfigManagerService.PlaybookGenerator.GeneratePlaybook(*payload)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return ctx.String(http.StatusOK, playbook)
+}

--- a/api/controllers/types.gen.go
+++ b/api/controllers/types.gen.go
@@ -42,7 +42,23 @@ type StateArchive struct {
 }
 
 // StateArchives defines model for StateArchives.
-type StateArchives []StateArchive
+type StateArchives struct {
+
+	// A number of entries returned from offset
+	Count *int `json:"count,omitempty"`
+
+	// A max number of entries to return
+	Limit *int `json:"limit,omitempty"`
+
+	// A number representing he starting point for retrieving entries
+	Offset *int `json:"offset,omitempty"`
+
+	// Query results
+	Results *[]StateArchive `json:"results,omitempty"`
+
+	// A total count of found entries
+	Total *int `json:"total,omitempty"`
+}
 
 // StateID defines model for StateID.
 type StateID string
@@ -72,6 +88,12 @@ type GetStatesParams struct {
 // UpdateStatesJSONBody defines parameters for UpdateStates.
 type UpdateStatesJSONBody State
 
+// GetPlaybookPreviewJSONBody defines parameters for GetPlaybookPreview.
+type GetPlaybookPreviewJSONBody State
+
 // UpdateStatesJSONRequestBody defines body for UpdateStates for application/json ContentType.
 type UpdateStatesJSONRequestBody UpdateStatesJSONBody
+
+// GetPlaybookPreviewJSONRequestBody defines body for GetPlaybookPreview for application/json ContentType.
+type GetPlaybookPreviewJSONRequestBody GetPlaybookPreviewJSONBody
 

--- a/application/config_manager_service.go
+++ b/application/config_manager_service.go
@@ -141,7 +141,7 @@ func (s *ConfigManagerService) ApplyState(
 // TODO: Add sorting and filtering
 // Sorting: currently only ascending
 // Filtering idea: may need to filter on user/initiator
-func (s *ConfigManagerService) GetStateChanges(accountID string, limit, offset int) ([]domain.StateArchive, error) {
+func (s *ConfigManagerService) GetStateChanges(accountID string, limit, offset int) (*domain.StateArchives, error) {
 	states, err := s.StateArchiveRepo.GetAllStateArchives(accountID, limit, offset)
 	if err != nil {
 		return nil, err

--- a/domain/state_archive.go
+++ b/domain/state_archive.go
@@ -15,9 +15,17 @@ type StateArchive struct {
 	State     StateMap  `db:"state" json:"state"`
 }
 
+type StateArchives struct {
+	Count  int            `json:"count"`
+	Limit  int            `json:"limit"`
+	Offset int            `json:"offset"`
+	Total  int            `json:"total"`
+	States []StateArchive `json:"results"`
+}
+
 type StateArchiveRepository interface {
 	GetStateArchive(s *StateArchive) (*StateArchive, error)
-	GetAllStateArchives(accountID string, limit, offset int) ([]StateArchive, error)
+	GetAllStateArchives(accountID string, limit, offset int) (*StateArchives, error)
 	DeleteStateArchive(s *StateArchive) error
 	CreateStateArchive(s *StateArchive) error
 }

--- a/schema/api.spec.yaml
+++ b/schema/api.spec.yaml
@@ -79,6 +79,28 @@ paths:
           description: Internal Server Error
           content: {}
 
+  /states/preview:
+    post:
+      summary: Get a preview of the playbook built from the provided state map
+      operationId: getPlaybookPreview
+      requestBody:
+        description: State map used to generate a preview playbook
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/State'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            text/vnd.yaml:
+              schema:
+                type: string
+        '400':
+          description: Bad Request
+          content: {}
+
   /states/{id}:
     get:
       summary: Get single state change for requesting account
@@ -181,9 +203,25 @@ components:
           $ref: '#/components/schemas/State'
         
     StateArchives:
-      type: array
-      items:
-        $ref: '#/components/schemas/StateArchive'
+      type: object
+      properties:
+        total:
+          description: A total count of found entries
+          type: integer
+        count:
+          description: A number of entries returned from offset
+          type: integer
+        limit:
+          description: A max number of entries to return
+          type: integer
+        offset:
+          description: A number representing he starting point for retrieving entries
+          type: integer
+        results:
+          description: Query results
+          type: array
+          items:
+            $ref: '#/components/schemas/StateArchive'
   
   parameters:
     StateIDParam:


### PR DESCRIPTION
@Ichimonji10 This PR changes the response format when performing a GET on /states. The array that used to be returned is now located in the "results" field of the response, and pagination metadata was also added. 