### PR TITLE
Updating connectors to behave correctly when using mocked implementation

### DIFF
--- a/infrastructure/container.go
+++ b/infrastructure/container.go
@@ -171,22 +171,14 @@ func (c *Container) ClientListRepo() *persistence.ClientListRepository {
 // DispatcherRepo enables interaction with the playbook dispatcher
 func (c *Container) DispatcherRepo() domain.DispatcherClient {
 	if c.dispatcherRepo == nil {
-		var client utils.HTTPClient
-		if c.Config.GetString("Dispatcher_Impl") == "mock" {
-			expectedResponse := `[
-				{"code": 200, "id": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7"},
-				{"code": 200, "id": "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4"}
-			]`
-			client = utils.SetupMockHTTPClient(expectedResponse, 200)
-		} else {
-			client = &http.Client{
-				Timeout: time.Duration(int(time.Second) * c.Config.GetInt("Dispatcher_Timeout")),
-			}
+		client := &http.Client{
+			Timeout: time.Duration(int(time.Second) * c.Config.GetInt("Dispatcher_Timeout")),
 		}
 
 		c.dispatcherRepo = &persistence.DispatcherClient{
 			DispatcherHost: c.Config.GetString("Dispatcher_Host"),
 			DispatcherPSK:  c.Config.GetString("Dispatcher_PSK"),
+			DispatcherImpl: c.Config.GetString("Dispatcher_Impl"),
 			Client:         client,
 		}
 	}
@@ -197,22 +189,15 @@ func (c *Container) DispatcherRepo() domain.DispatcherClient {
 // CloudConnectorRepo enables interaction with the cloud connector
 func (c *Container) CloudConnectorRepo() domain.CloudConnectorClient {
 	if c.cloudConnectorRepo == nil {
-		var client utils.HTTPClient
-		if c.Config.GetString("Cloud_Connector_Impl") == "mock" {
-			expectedResponse := `{
-				"connections": ["3d711f8b-77d0-4ed5-a5b5-1d282bf930c7", "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4"]
-			}`
-			client = utils.SetupMockHTTPClient(expectedResponse, 200)
-		} else {
-			client = &http.Client{
-				Timeout: time.Duration(int(time.Second) * c.Config.GetInt("Cloud_Connector_Timeout")),
-			}
+		client := &http.Client{
+			Timeout: time.Duration(int(time.Second) * c.Config.GetInt("Cloud_Connector_Timeout")),
 		}
 
 		c.cloudConnectorRepo = &persistence.CloudConnectorClient{
 			CloudConnectorHost:     c.Config.GetString("Cloud_Connector_Host"),
 			CloudConnectorClientID: c.Config.GetString("Cloud_Connector_Client_ID"),
 			CloudConnectorPSK:      c.Config.GetString("Cloud_Connector_PSK"),
+			CloudConnectorImpl:     c.Config.GetString("Cloud_Connector_Impl"),
 			Client:                 client,
 		}
 	}

--- a/infrastructure/persistence/cloud_connector_repository.go
+++ b/infrastructure/persistence/cloud_connector_repository.go
@@ -20,6 +20,7 @@ type CloudConnectorClient struct {
 	CloudConnectorClientID string
 	CloudConnectorPSK      string
 	Client                 utils.HTTPClient
+	CloudConnectorImpl     string
 }
 
 func (c *CloudConnectorClient) GetConnections(
@@ -27,6 +28,15 @@ func (c *CloudConnectorClient) GetConnections(
 	accountID string,
 ) ([]string, error) {
 	fmt.Println("Sending request to cloud connector")
+
+	if c.CloudConnectorImpl == "mock" {
+		expectedResponse := []byte(`{
+			"connections": ["3d711f8b-77d0-4ed5-a5b5-1d282bf930c7", "74368f32-4e6d-4ea2-9b8f-22dac89f9ae4"]
+		}`)
+		var cloudConnectorRes domain.CloudConnectorConnections
+		err := json.Unmarshal(expectedResponse, &cloudConnectorRes)
+		return cloudConnectorRes.Connections, err
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", c.CloudConnectorHost+"/api/cloud-connector/v1/connection/"+accountID, nil)
 	if err != nil {


### PR DESCRIPTION
@Ichimonji10 This should allow the local tests to pass properly while still preserving the mocked clients for unit testing. Let me know if you still see any issues.