### PR TITLE
Adding additional restrictions when updating service states

### DIFF
--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"config-manager/application"
 	"config-manager/domain"
+	"config-manager/utils"
 	"context"
 	"encoding/json"
 	"io/ioutil"
@@ -131,6 +132,12 @@ func (cmc *ConfigManagerController) UpdateStates(ctx echo.Context) error {
 	}
 
 	currentState, err := cmc.ConfigManagerService.GetAccountState(id.Identity.AccountNumber)
+
+	err = utils.VerifyStatePayload(currentState.State, *payload)
+	if err != nil {
+		log.Printf("Payload verification error: %s", err.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
 
 	acc, err := cmc.ConfigManagerService.UpdateAccountState(id.Identity.AccountNumber, "demo-user", *payload)
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,10 +2,12 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -53,4 +55,20 @@ func FilesIntoMap(dir, pattern string) map[string][]byte {
 	}
 
 	return filesMap
+}
+
+func VerifyStatePayload(currentState, payload map[string]string) error {
+	if reflect.DeepEqual(currentState, payload) {
+		return fmt.Errorf("Provided payload %+v is equal to current state %+v", payload, currentState)
+	}
+
+	if payload["insights"] == "disabled" {
+		for k, v := range payload {
+			if v != "disabled" {
+				return fmt.Errorf("Service %s must be disabled if insights is disabled", k)
+			}
+		}
+	}
+
+	return nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,71 @@
+package utils_test
+
+import (
+	"config-manager/utils"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var verifyPayloadTests = []struct {
+	name         string
+	currentState map[string]string
+	payload      map[string]string
+	errorThrown  bool
+}{
+	{
+		"valid payload",
+		map[string]string{
+			"insights":            "enabled",
+			"remediations":        "enabled",
+			"compliance_openscap": "enabled",
+		},
+		map[string]string{
+			"insights":            "enabled",
+			"remediations":        "enabled",
+			"compliance_openscap": "disabled",
+		},
+		false,
+	},
+	{
+		"payload equal to current state",
+		map[string]string{
+			"insights":            "enabled",
+			"remediations":        "enabled",
+			"compliance_openscap": "enabled",
+		},
+		map[string]string{
+			"insights":            "enabled",
+			"remediations":        "enabled",
+			"compliance_openscap": "enabled",
+		},
+		true,
+	},
+	{
+		"additional services enabled when insights is disabled",
+		map[string]string{
+			"insights":            "enabled",
+			"remediations":        "enabled",
+			"compliance_openscap": "enabled",
+		},
+		map[string]string{
+			"insights":            "disabled",
+			"remediations":        "enabled",
+			"compliance_openscap": "enabled",
+		},
+		true,
+	},
+}
+
+func TestVerifyStatePayload(t *testing.T) {
+	for _, tt := range verifyPayloadTests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := utils.VerifyStatePayload(tt.currentState, tt.payload)
+			if tt.errorThrown {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHCLOUD-13763

This change does two things:
1. Check to see if the provided state is the same as the current state - if they're the same don't create a new state change and let the client know
2. If "insights" is disabled make sure the additional services are also disabled - if they aren't don't make any changes and let the client know

@dehort this solution isn't generic enough, but it will be updated once there is more logic built around the services themselves (ie make a distinction between parent/child services to validate the states without specifically calling out 'insights')

Currently it will return a 400 for both of the above cases, but it may also make sense to return a 200 and then the unchanged current state?