### PR TITLE
Use both data sources for connected accounts

### DIFF
--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -55,7 +55,7 @@ func (cmc *ConfigManagerController) getClients(ctx echo.Context, currentState do
 	//TODO There's probably a better way to do this
 	ctxWithID := context.WithValue(ctx.Request().Context(), "X-Rh-Identity", ctx.Request().Header["X-Rh-Identity"][0])
 	var clients []domain.Host
-	var inventoryRHCIDs map[string]bool
+	inventoryRHCIDs := make(map[string]bool)
 	var err error
 
 	// workaround: If insights is disabled - get clients from cloud-connector instead of inventory

--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -55,6 +55,7 @@ func (cmc *ConfigManagerController) getClients(ctx echo.Context, currentState do
 	//TODO There's probably a better way to do this
 	ctxWithID := context.WithValue(ctx.Request().Context(), "X-Rh-Identity", ctx.Request().Header["X-Rh-Identity"][0])
 	var clients []domain.Host
+	var inventoryRHCIDs map[string]bool
 	var err error
 
 	// workaround: If insights is disabled - get clients from cloud-connector instead of inventory
@@ -65,6 +66,9 @@ func (cmc *ConfigManagerController) getClients(ctx echo.Context, currentState do
 			return nil, err
 		}
 		clients = append(clients, res.Results...)
+		for _, client := range res.Results {
+			inventoryRHCIDs[client.SystemProfile.RHCID] = true
+		}
 
 		for len(clients) < res.Total {
 			page := res.Page + 1
@@ -73,14 +77,19 @@ func (cmc *ConfigManagerController) getClients(ctx echo.Context, currentState do
 				return nil, err
 			}
 			clients = append(clients, res.Results...)
+			for _, client := range res.Results {
+				inventoryRHCIDs[client.SystemProfile.RHCID] = true
+			}
 		}
-	} else {
-		res, err := cmc.ConfigManagerService.GetConnectedClients(ctxWithID, currentState.AccountID)
-		if err != nil {
-			return nil, err
-		}
+	}
 
-		for clientID := range res {
+	res, err := cmc.ConfigManagerService.GetConnectedClients(ctxWithID, currentState.AccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	for clientID := range res {
+		if !inventoryRHCIDs[clientID] {
 			clients = append(clients, domain.Host{
 				Account: currentState.AccountID,
 				SystemProfile: domain.SystemProfile{


### PR DESCRIPTION
@dehort @rodrigonull This PR aims to resolve the case where RHC connected hosts are ignored due to the host entry in inventory missing the rhc_client_id. This can happen by turning off/on the insights-client causing inventory records to be regenerated without the rhc_client_id being present in the system_profile.

Config-manager will first attempt to gather any connected hosts through inventory, and then record the found rhc_client_ids. It will then also gather connected hosts through cloud-connector and merge the results to ensure no hosts are ignored due to a missing rhc_client_id. 