### PR TITLE
Add autolabeler for stale signatures

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+re-sign:
+  - playbooks/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,22 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Add autolabeler for stale template signatures.

This github action will automatically label any PR that changes the templates stored in the config-manager repo.  This will allow the GITHUB slack integration to pick it up and alert the pipeline team whenever a signature needs to be re-signed.

JIRA: https://issues.redhat.com/browse/RHCLOUD-13831