### PR TITLE
fix: use global value key when creating context

### DIFF
--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -14,6 +14,7 @@ import (
 	"config-manager/api/instrumentation"
 	"config-manager/application"
 	"config-manager/domain"
+	"config-manager/infrastructure/persistence"
 	"config-manager/utils"
 	"context"
 	"encoding/json"
@@ -74,7 +75,7 @@ func translateStatesParams(params GetStatesParams) map[string]interface{} {
 // ID extracted from the X-Rh-Identity header.
 func (cmc *ConfigManagerController) getClients(ctx echo.Context) ([]domain.Host, error) {
 	//TODO There's probably a better way to do this
-	ctxWithID := context.WithValue(ctx.Request().Context(), "X-Rh-Identity", ctx.Request().Header["X-Rh-Identity"][0])
+	ctxWithID := context.WithValue(ctx.Request().Context(), persistence.IdentityKey, ctx.Request().Header["X-Rh-Identity"][0])
 	var clients []domain.Host
 	var err error
 


### PR DESCRIPTION
The context.Value() call was updated to use the persistence.IdentityKey
global variable when finding the context value. Use the same key when
creating the context too.

Fixes: ESSNTL-2707