### PR TITLE
fix: check return error for value

### DIFF
--- a/api/controllers/config_manager_controller.go
+++ b/api/controllers/config_manager_controller.go
@@ -142,6 +142,9 @@ func (cmc *ConfigManagerController) UpdateStates(ctx echo.Context) error {
 	}
 
 	currentState, err := cmc.ConfigManagerService.GetAccountState(id.Identity.AccountNumber)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 
 	equal, err := utils.VerifyStatePayload(currentState.State, *payload)
 	if err != nil {


### PR DESCRIPTION
Check the returned error from GetAccountState for a value and return an
HTTP error if an error is detected.