### PR TITLE
Handle kafka message concurrently

### DIFF
--- a/application/config_manager_service.go
+++ b/application/config_manager_service.go
@@ -299,10 +299,10 @@ func (s *ConfigManagerService) SetupHost(ctx context.Context, host domain.Host) 
 		return "", err
 	}
 
-	var tries = 0
+	started := time.Now()
 	for {
-		if tries > 5 {
-			return "", fmt.Errorf("unable to detect rhc-worker-playbook after %v tries", tries)
+		if time.Now().After(started.Add(180 * time.Second)) {
+			return "", fmt.Errorf("unable to detect rhc-worker-playbook after %v, aborting", time.Since(started))
 		}
 		status, dispatchers, err := s.CloudConnectorRepo.GetConnectionStatus(ctx, host.Account, host.SystemProfile.RHCID)
 		if err != nil {
@@ -318,7 +318,6 @@ func (s *ConfigManagerService) SetupHost(ctx context.Context, host domain.Host) 
 			logger.Debug().Interface("dispatchers", dispatchers).Msg("found rhc-worker-playbook dispatcher")
 			break
 		}
-		tries += 1
 		time.Sleep(30 * time.Second)
 	}
 

--- a/infrastructure/kafka/kafka.go
+++ b/infrastructure/kafka/kafka.go
@@ -62,7 +62,7 @@ func NewConsumerEventLoop(
 				log.Info().Err(err)
 				errors <- err
 			}
-			handler(ctx, m)
+			go handler(ctx, m)
 		}
 	}
 }


### PR DESCRIPTION
After reading the next message from a kafka reader, handle it in a goroutine rather than on the current thread. This enables multiple messages to be handled simultaneously. If one host is taking a while to install rhc-worker-playbook, it will no longer block the other hosts from being set up.