### PR TITLE
refactor: use account and org_id in the kafka handler

### DIFF
--- a/dispatcher-consumer/handler.go
+++ b/dispatcher-consumer/handler.go
@@ -29,8 +29,9 @@ func buildMessage(payload message.DispatcherEventPayload, reqID uuid.UUID) ([]by
 		Operation: "add_host",
 		Metadata:  message.PlatformMetadata{RequestID: reqID.String()},
 		Data: message.HostUpdateData{
-			ID:    payload.Labels["id"],
-			OrgID: payload.OrgID,
+			ID:      payload.Labels["id"],
+			OrgID:   payload.OrgID,
+			Account: payload.Account,
 			SystemProfile: message.HostUpdateSystemProfile{
 				RHCState: payload.Labels["state_id"],
 			},
@@ -84,8 +85,8 @@ func (this *handler) onMessage(ctx context.Context, msg kafka.Message) {
 			if err != nil {
 				log.Info().Msgf("Error producing message to system profile topic. request_id: %v", reqID.String())
 			} else {
-				log.Info().Msgf("Message sent to inventory with request_id: %s, host_id: %s, org_id: %s",
-					reqID.String(), value.Payload.Labels["id"], value.Payload.OrgID)
+				log.Info().Msgf("Message sent to inventory with request_id: %s, host_id: %s, account: %s, org_id: %s",
+					reqID.String(), value.Payload.Labels["id"], value.Payload.Account, value.Payload.OrgID)
 			}
 		case "running":
 			log.Info().Msgf("Received running event for host %v", value.Payload.Recipient)

--- a/dispatcher-consumer/handler_test.go
+++ b/dispatcher-consumer/handler_test.go
@@ -35,7 +35,8 @@ var tests = []struct {
 	eventService string
 	requestID    string
 	data         []byte
-	org_id       string
+	orgID        string
+	account      string
 	stateID      string
 	invMsgSent   bool
 	validEvent   bool
@@ -49,6 +50,7 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
+				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -60,6 +62,7 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
+		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		false,
 		true,
@@ -73,6 +76,7 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
+				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -84,6 +88,7 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
+		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		true,
 		true,
@@ -97,6 +102,7 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
+				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -108,6 +114,7 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
+		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		false,
 		true,
@@ -121,6 +128,7 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
+				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -132,6 +140,7 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
+		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		false,
 		false,
@@ -216,7 +225,8 @@ func TestDispatcherMessageBuilder(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, invMsg.Metadata.RequestID, tt.requestID)
-			assert.Equal(t, invMsg.Data.OrgID, tt.org_id)
+			assert.Equal(t, invMsg.Data.Account, tt.account)
+			assert.Equal(t, invMsg.Data.OrgID, tt.orgID)
 			assert.Equal(t, invMsg.Data.ID, value.Payload.Labels["id"])
 			assert.Equal(t, invMsg.Data.SystemProfile.RHCState, tt.stateID)
 		})

--- a/domain/message/dispatcher.go
+++ b/domain/message/dispatcher.go
@@ -12,6 +12,7 @@ type DispatcherEvent struct {
 type DispatcherEventPayload struct {
 	ID            string            `json:"id"`
 	OrgID         string            `json:"org_id"`
+	Account       string            `json:"account"`
 	Recipient     string            `json:"recipient"`
 	CorrelationID string            `json:"correlation_id"`
 	Service       string            `json:"service"`

--- a/domain/message/inventory.go
+++ b/domain/message/inventory.go
@@ -26,6 +26,7 @@ type PlatformMetadata struct {
 type HostUpdateData struct {
 	ID            string                  `json:"id"`
 	OrgID         string                  `json:"org_id"`
+	Account       string                  `json:"account"`
 	SystemProfile HostUpdateSystemProfile `json:"system_profile"`
 }
 


### PR DESCRIPTION
This adds back the account field that was removed in commit 1a4f3047665521aba09619ea7b09910fd1eeb38e.

This field can be removed after the completion of [ESSNTL-2529](https://issues.redhat.com/browse/ESSNTL-2529). 