### PR TITLE
refactor: remove account field from kafka handler

### DIFF
--- a/dispatcher-consumer/handler.go
+++ b/dispatcher-consumer/handler.go
@@ -29,9 +29,8 @@ func buildMessage(payload message.DispatcherEventPayload, reqID uuid.UUID) ([]by
 		Operation: "add_host",
 		Metadata:  message.PlatformMetadata{RequestID: reqID.String()},
 		Data: message.HostUpdateData{
-			ID:      payload.Labels["id"],
-			OrgID:   payload.OrgID,
-			Account: payload.Account,
+			ID:    payload.Labels["id"],
+			OrgID: payload.OrgID,
 			SystemProfile: message.HostUpdateSystemProfile{
 				RHCState: payload.Labels["state_id"],
 			},
@@ -85,8 +84,8 @@ func (this *handler) onMessage(ctx context.Context, msg kafka.Message) {
 			if err != nil {
 				log.Info().Msgf("Error producing message to system profile topic. request_id: %v", reqID.String())
 			} else {
-				log.Info().Msgf("Message sent to inventory with request_id: %s, host_id: %s, account: %s, org_id: %s",
-					reqID.String(), value.Payload.Labels["id"], value.Payload.Account, value.Payload.OrgID)
+				log.Info().Msgf("Message sent to inventory with request_id: %s, host_id: %s, org_id: %s",
+					reqID.String(), value.Payload.Labels["id"], value.Payload.OrgID)
 			}
 		case "running":
 			log.Info().Msgf("Received running event for host %v", value.Payload.Recipient)

--- a/dispatcher-consumer/handler_test.go
+++ b/dispatcher-consumer/handler_test.go
@@ -36,7 +36,6 @@ var tests = []struct {
 	requestID    string
 	data         []byte
 	orgID        string
-	account      string
 	stateID      string
 	invMsgSent   bool
 	validEvent   bool
@@ -50,7 +49,6 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
-				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -62,7 +60,6 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
-		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		false,
 		true,
@@ -76,7 +73,6 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
-				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -88,7 +84,6 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
-		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		true,
 		true,
@@ -102,7 +97,6 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
-				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -114,7 +108,6 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
-		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		false,
 		true,
@@ -128,7 +121,6 @@ var tests = []struct {
 			"payload": {
 				"id": "1234",
 				"org_id": "5318290",
-				"account": "0000001",
 				"recipient": "3d711f8b-77d0-4ed5-a5b5-1d282bf930c7",
 				"correlation_id": "62156f8e-9dfd-4103-a60d-31f6090a3241",
 				"service": "config_manager",
@@ -140,7 +132,6 @@ var tests = []struct {
 			}
 		}`),
 		"5318290",
-		"0000001",
 		"88d2706a-a9da-4aa4-a6fd-9750bcb4714f",
 		false,
 		false,
@@ -225,7 +216,6 @@ func TestDispatcherMessageBuilder(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, invMsg.Metadata.RequestID, tt.requestID)
-			assert.Equal(t, invMsg.Data.Account, tt.account)
 			assert.Equal(t, invMsg.Data.OrgID, tt.orgID)
 			assert.Equal(t, invMsg.Data.ID, value.Payload.Labels["id"])
 			assert.Equal(t, invMsg.Data.SystemProfile.RHCState, tt.stateID)

--- a/domain/message/dispatcher.go
+++ b/domain/message/dispatcher.go
@@ -12,7 +12,6 @@ type DispatcherEvent struct {
 type DispatcherEventPayload struct {
 	ID            string            `json:"id"`
 	OrgID         string            `json:"org_id"`
-	Account       string            `json:"account"`
 	Recipient     string            `json:"recipient"`
 	CorrelationID string            `json:"correlation_id"`
 	Service       string            `json:"service"`

--- a/domain/message/inventory.go
+++ b/domain/message/inventory.go
@@ -26,7 +26,6 @@ type PlatformMetadata struct {
 type HostUpdateData struct {
 	ID            string                  `json:"id"`
 	OrgID         string                  `json:"org_id"`
-	Account       string                  `json:"account"`
 	SystemProfile HostUpdateSystemProfile `json:"system_profile"`
 }
 


### PR DESCRIPTION
Removes the `account` field as part of [RHCLOUD-20315](https://issues.redhat.com/browse/RHCLOUD-20315)

Field is no longer required as of [ESSNTL-2529](https://issues.redhat.com/browse/ESSNTL-2529)