### PR TITLE
feat: downgrade the openapi spec version to 3.0.0

### DIFF
--- a/internal/http/v1/openapi.yaml
+++ b/internal/http/v1/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.1
+openapi: 3.0.0
 info:
   title: Config manager
   description: Config manager service


### PR DESCRIPTION
console.redhat.com/docs/api wants openapi version 3.0.0, not 3.1.x