### PR TITLE
fix: decrease the populator batch size to 50

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -304,6 +304,8 @@ objects:
           - ${PROMETHEUS_PUSHGATEWAY}
           - --db-operation-timeout
           - ${POPULATOR_OPERATION_TIMEOUT}
+          - --batch-size
+          - ${POPULATOR_BATCH_SIZE}
         env:
           - name: LOG_FORMAT
             value: ${POPULATOR_LOG_FORMAT}
@@ -386,8 +388,10 @@ parameters:
 - name: POPULATOR_IMAGE_TAG
   value: latest
 - name: POPULATOR_RUN_NUMBER # in case we need to run populator again, just increment this
-  value: "1"
+  value: "2"
 - name: POPULATOR_OPERATION_TIMEOUT
   value: "10"
 - name: PROMETHEUS_PUSHGATEWAY
   value: "localhost"
+- name: POPULATOR_BATCH_SIZE
+  value: "50"


### PR DESCRIPTION
Decrease the org-id-populator CJI batch size from 100 to 50. This will hopefully solve issues with the failed translation job in PROD.