### PR TITLE
batch runs to playbook-dispatcher correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ You only need to do this once.
 
 ### Start `minikube`
 
+`minikube` runs as a libvirt domain. Setting the default libvirt connection URI
+and adding your user account to the `libvirt` UNIX group makes interacting with
+libvirt easier.
+
+```sh
+echo "LIBVIRT_DEFAULT_URI=qemu:////system" >> ~/.bashrc
+sudo usermod -a -G libvirt $USER
+```
+
+Log out or reboot after adding yourself to the group to ensure the seat is
+completely logged out.
+
 ```sh
 minikube start --cpus 8 --disk-size 36GB --memory 16GB --addons=registry --driver=kvm2
 ```

--- a/infrastructure/persistence/cloudconnector/cloudconnector.go
+++ b/infrastructure/persistence/cloudconnector/cloudconnector.go
@@ -145,11 +145,11 @@ func (c *cloudConnectorClientImpl) GetConnectionStatus(ctx context.Context, acco
 		logger.Trace().Str("method", req.Method).Str("url", req.URL.String()).Interface("headers", req.Header).Msg("sending HTTP request")
 		return nil
 	})
-	logger.Trace().Str("http_status", http.StatusText(resp.StatusCode)).Interface("headers", resp.Header).Msg("received HTTP response")
 	if err != nil {
 		logger.Error().Err(err).Msg("cannot get connection status")
 		return "unknown", nil, err
 	}
+	logger.Trace().Str("http_status", http.StatusText(resp.StatusCode)).Interface("headers", resp.Header).Msg("received HTTP response")
 	response, err := ParsePostConnectionStatusResponse(resp)
 	logger.Debug().Str("response", string(response.Body)).Msg("parsed HTTP response")
 	if err != nil {

--- a/internal/http/v1/handlers.go
+++ b/internal/http/v1/handlers.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"config-manager/infrastructure/persistence/dispatcher"
 	"config-manager/infrastructure/persistence/inventory"
 	"config-manager/internal"
 	"config-manager/internal/config"
@@ -130,12 +131,13 @@ func postStates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go func() {
-		results, err := internal.ApplyProfile(r.Context(), &newProfile, clients)
+		internal.ApplyProfile(r.Context(), &newProfile, clients, func(results []dispatcher.RunCreated) {
+			logger.Info().Interface("results", results).Msg("response from dispatcher")
+		})
 		if err != nil {
 			instrumentation.UpdateAccountStateError()
 			logger.Error().Err(err).Msg("error applying state")
 		}
-		logger.Info().Interface("results", results).Msg("response from dispatcher")
 	}()
 
 	resp := accountState{

--- a/internal/util/batch.go
+++ b/internal/util/batch.go
@@ -1,0 +1,38 @@
+package util
+
+import "errors"
+
+var Batch batchutil
+
+type batchutil struct{}
+
+// BatchFunc is called for each batch.
+// Any error will cancel the batching operation but returning Abort
+// indicates it was deliberate, and not an error case.
+type BatchFunc func(start, end int) error
+
+// ErrAbort is a sentinal error as defined by Dave Cheney (@davecheney) which
+// indicates a batch operation should abort early.
+var ErrAbort = errors.New("done")
+
+// All calls eachFn for all items
+// Returns any error from eachFn except for Abort it returns nil.
+func (b batchutil) All(count, batchSize int, eachFn BatchFunc) error {
+	i := 0
+	for i < count {
+		end := i + batchSize - 1
+		if end > count-1 {
+			// passed end, so set to end item
+			end = count - 1
+		}
+		err := eachFn(i, end)
+		if err == ErrAbort {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		i = end + 1
+	}
+	return nil
+}

--- a/internal/util/batch_test.go
+++ b/internal/util/batch_test.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestBatchAll(t *testing.T) {
+	type Range struct {
+		start, end int
+	}
+
+	tests := []struct {
+		description string
+		input       struct {
+			count     int
+			batchSize int
+		}
+		want      []Range
+		wantError error
+	}{
+		{
+			description: "count equals batch size",
+			input: struct {
+				count     int
+				batchSize int
+			}{
+				count:     1,
+				batchSize: 1,
+			},
+			want: []Range{{0, 0}},
+		},
+		{
+			description: "count less than batch size",
+			input: struct {
+				count     int
+				batchSize int
+			}{
+				count:     5,
+				batchSize: 10,
+			},
+			want: []Range{{0, 4}},
+		},
+		{
+			description: "count greater than batch size",
+			input: struct {
+				count     int
+				batchSize int
+			}{
+				count:     15,
+				batchSize: 10,
+			},
+			want: []Range{{0, 9}, {10, 14}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			var got []Range
+			err := Batch.All(test.input.count, test.input.batchSize, func(start, end int) error {
+				got = append(got, Range{start, end})
+				return nil
+			})
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(got, test.want, cmp.AllowUnexported(Range{})) {
+					t.Errorf("%v", cmp.Diff(got, test.want, cmp.AllowUnexported(Range{})))
+				}
+			}
+		})
+	}
+}

--- a/scripts/bonfire.yml
+++ b/scripts/bonfire.yml
@@ -13,6 +13,31 @@ apps:
           CM_CLOUD_CONNECTOR_HOST: http://cloud-connector:8080/
           TENANT_TRANSLATOR_HOST: mock
           TENANT_TRANSLATOR_IMPL: mock
+  - name: cloud-connector
+    components:
+      - name: cloud-connector-api
+        host: github
+        repo: RedHatInsights/cloud-connector
+        path: deploy/clowdapp.yml
+        parameters:
+          LOG_FORMAT: "TEXT"
+          MQTT_BROKER_TLS_SKIP_VERIFY: true
+          MQTT_BROKER_ADDRESS: tcp://mosquitto:1883
+          CLIENT_ID_TO_ACCOUNT_ID_IMPL: config_file_based
+          CLIENT_ID_TO_ACCOUNT_ID_DEFAULT_ACCOUNT_ID: "6399897"
+          CLIENT_ID_TO_ACCOUNT_ID_DEFAULT_ORG_ID: "12671438"
+          SOURCES_RECORDER_IMPL: fake
+          CONNECTED_CLIENT_RECORDER_IMPL: inventory
+          INVENTORY_KAFKA_BATCH_SIZE: 1
+          RHC_MESSAGE_KAFKA_BATCH_SIZE: 1
+          API_SERVER_CONNECTION_LOOKUP_IMPL: relaxed
+          TENANT_TRANSLATOR_HOST: mock
+          TENANT_TRANSLATOR_IMPL: mock
+          TENANT_TRANSLATOR_MOCK_MAPPING: '{"12671438": "6399897"}'
+      - name: mosquitto-broker
+        host: github
+        repo: RedHatInsights/cloud-connector
+        path: deploy/mosquitto.yml
   - name: playbook-dispatcher
     components:
       - name: playbook-dispatcher


### PR DESCRIPTION
Rewrite the ApplyProfile batch processing code to use a separate
batching function. Instead of running the code synchronously, each batch
is sent to playbook-dispatcher on a groutine. ApplyProfile accepts
a function that is called when the batch receives a response from
playbook-dispatcher.

Fixes: ESSNTL-3238