### PR TITLE
fix: use per_reporter_staleness to detect reporter

### DIFF
--- a/infrastructure/persistence/cloudconnector/cloudconnector_test.go
+++ b/infrastructure/persistence/cloudconnector/cloudconnector_test.go
@@ -53,7 +53,7 @@ func TestGetConnections(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			rand.Seed(time.Now().UnixNano())
-			port := uint32(rand.Int31n(10000-8080) + 8080)
+			port := uint32(rand.Int31n(65535-55535) + 55535)
 
 			config.DefaultConfig.CloudConnectorHost.Value = url.MustParse(fmt.Sprintf("http://localhost:%v", port))
 			config.DefaultConfig.CloudConnectorClientID = "test"
@@ -130,7 +130,7 @@ func TestSendMessage(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			rand.Seed(time.Now().UnixNano())
-			port := uint32(rand.Int31n(10000-8080) + 8080)
+			port := uint32(rand.Int31n(65535-55535) + 55535)
 
 			config.DefaultConfig.CloudConnectorHost.Value = url.MustParse(fmt.Sprintf("http://localhost:%v", port))
 			config.DefaultConfig.CloudConnectorClientID = "test"
@@ -208,7 +208,7 @@ func TestGetConnectionStatus(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			rand.Seed(time.Now().UnixNano())
-			port := uint32(rand.Int31n(10000-8080) + 8080)
+			port := uint32(rand.Int31n(65535-55535) + 55535)
 
 			config.DefaultConfig.CloudConnectorHost.Value = url.MustParse(fmt.Sprintf("http://localhost:%v", port))
 			config.DefaultConfig.CloudConnectorClientID = "test"

--- a/infrastructure/persistence/dispatcher/dispatcher_test.go
+++ b/infrastructure/persistence/dispatcher/dispatcher_test.go
@@ -109,7 +109,7 @@ func TestDispatch(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			rand.Seed(time.Now().UnixNano())
-			port := uint32(rand.Int31n(10000-8080) + 8080)
+			port := uint32(rand.Int31n(65535-55535) + 55535)
 
 			config.DefaultConfig.DispatcherHost.Value = url.MustParse(fmt.Sprintf("http://localhost:%v", port))
 

--- a/infrastructure/persistence/inventory/inventory_repository_test.go
+++ b/infrastructure/persistence/inventory/inventory_repository_test.go
@@ -75,7 +75,7 @@ func TestGetInventoryClients(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			rand.Seed(time.Now().UnixNano())
-			port := uint32(rand.Int31n(10000-8080) + 8080)
+			port := uint32(rand.Int31n(65535-55535) + 55535)
 
 			config.DefaultConfig.InventoryHost.Value = url.MustParse(fmt.Sprintf("http://localhost:%v", port))
 

--- a/internal/host.go
+++ b/internal/host.go
@@ -16,12 +16,13 @@ import (
 
 // Host represents a system record from the Inventory application.
 type Host struct {
-	ID            string `json:"id"`
-	Account       string `json:"account"`
-	OrgID         string `json:"org_id"`
-	DisplayName   string `json:"display_name"`
-	Reporter      string `json:"reporter"`
-	SystemProfile struct {
+	ID                   string                 `json:"id"`
+	Account              string                 `json:"account"`
+	OrgID                string                 `json:"org_id"`
+	DisplayName          string                 `json:"display_name"`
+	Reporter             string                 `json:"reporter"`
+	PerReporterStaleness map[string]interface{} `json:"per_reporter_staleness"`
+	SystemProfile        struct {
 		RHCID    string `json:"rhc_client_id"`
 		RHCState string `json:"rhc_config_state"`
 	} `json:"system_profile"`
@@ -40,7 +41,7 @@ func ApplyProfile(ctx context.Context, profile *db.Profile, hosts []Host, fn fun
 
 	runs := make([]dispatcher.RunInput, 0, len(hosts))
 	for _, host := range hosts {
-		if host.Reporter != "cloud-connector" {
+		if _, has := host.PerReporterStaleness["cloud-connector"]; !has {
 			continue
 		}
 		logger.Debug().Str("client_id", host.SystemProfile.RHCID).Msg("creating run for host")


### PR DESCRIPTION
The "reporter" field only contains the most recent reporter for a host.
In order to send a state playbook to a host, config-manager needs to
know if it was ever reported by "cloud-connector", rather than if it was
most recently reported. The "per_reporter_staleness" field contains a
map of all reporters for the host, so using the presence or absence of a
key in that map correctly identifies whether a host has ever been
reported by cloud-connector.

Fixes: ESSNTL-3287