### PR TITLE
Include apiPath for public web service in clowdapp

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -54,6 +54,7 @@ objects:
       webServices:
         public:
           enabled: True
+          apiPath: config-manager
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         args:


### PR DESCRIPTION
This PR adds an apiPath to the webservice so the frontend can find it in the new containerized system