### PR TITLE
feat: add 'configuring' table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,7 @@ ht GET http://localhost:8080/api/config-manager/v1/states/current x-rh-identity:
 
 ```sh
 # Identify the environment name and export it
-export CONFIG_MANAGER_ENV=$(kubectl -n fog get svc -l env=env-fog,app.kubernetes.io/name=kafka -o json | jq '.items[0].metadata.labels["app.kubernetes.io/instance"]' -r)
+export CONFIG_MANAGER_ENV=$(minikube kubectl -- -n fog get svc -l env=env-fog,app.kubernetes.io/name=kafka -o json | jq '.items[0].metadata.labels["app.kubernetes.io/instance"]' -r)
 minikube kubectl -- -n fog run -it --rm --image=edenhill/kcat:1.7.1 kcat -- -b $CONFIG_MANAGER_ENV-kafka-bootstrap.fog.svc.cluster.local:9092 -t platform.inventory.events
 ```
 
@@ -214,6 +214,6 @@ minikube kubectl -- -n fog run -it --rm --image=edenhill/kcat:1.7.1 kcat -- -b $
 
 ```sh
 # Identify the environment name and export it
-export CONFIG_MANAGER_ENV=$(kubectl -n fog get svc -l env=env-fog,app.kubernetes.io/name=kafka -o json | jq '.items[0].metadata.labels["app.kubernetes.io/instance"]' -r)
-jq --compact-output --null-input --arg id $(uuidgen | tr -d "\n") '{"type":"created","host":{"id":$id,"account":"0000001","reporter":"cloud-connector","system_profile":{"rhc_client_id":$id}}}' | minikube kubectl -- -n fog run -i --rm --image=edenhill/kcat:1.7.1 $(mktemp XXXXXX) -- -b $CONFIG_MANAGER_ENV-kafka-bootstrap.fog.svc.cluster.local:9092 -t platform.inventory.events -P -H event_type=created 
+export CONFIG_MANAGER_ENV=$(minikube kubectl -- -n fog get svc -l env=env-fog,app.kubernetes.io/name=kafka -o json | jq '.items[0].metadata.labels["app.kubernetes.io/instance"]' -r)
+jq --compact-output --null-input --arg id $(uuidgen | tr -d "\n") '{"type":"created","host":{"id":$id,"subscription_manager_id":$id,"account":"0000001","reporter":"cloud-connector","system_profile":{"rhc_client_id":$id}}}' | minikube kubectl -- -n fog run -i --rm --image=edenhill/kcat:1.7.1 $(pwgen -1 --no-capitalize --no-numerals 8) -- -b $CONFIG_MANAGER_ENV-kafka-bootstrap.fog.svc.cluster.local:9092 -t platform.inventory.events -P -H event_type=created 
 ```

--- a/internal/cmd/dispatcherconsumer/cmd.go
+++ b/internal/cmd/dispatcherconsumer/cmd.go
@@ -2,6 +2,7 @@ package dispatcherconsumer
 
 import (
 	"config-manager/internal/config"
+	"config-manager/internal/db"
 	"config-manager/internal/util"
 	"context"
 	"encoding/json"
@@ -120,6 +121,11 @@ func handler(ctx context.Context, writer *kafka.Writer, msg kafka.Message) {
 					Value: data,
 				},
 			)
+
+			if err := db.DeleteConfiguring(value.Payload.Recipient, value.Payload.Labels["state_id"]); err != nil {
+				log.Error().Err(err).Str("host_id", value.Payload.Recipient).Str("profile_id", value.Payload.Labels["state_id"]).Msg("cannot delete row from configuring table")
+			}
+
 			if err != nil {
 				log.Info().Msgf("Error producing message to system profile topic. request_id: %v", reqID.String())
 			} else {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -211,6 +211,56 @@ func CountProfiles(orgID string) (int, error) {
 	return count, nil
 }
 
+// InsertConfiguring creates a row in the configuring table with the provided
+// host ID and profile ID.
+func InsertConfiguring(hostID string, profileID string) error {
+	stmt, err := preparedStatement(`INSERT INTO configuring (host_id, profile_id) VALUES ($1, $2);`)
+	if err != nil {
+		return fmt.Errorf("cannot prepare INSERT: %w", err)
+	}
+
+	_, err = stmt.Exec(hostID, profileID)
+	if err != nil {
+		return fmt.Errorf("cannot execute INSERT: %w", err)
+	}
+
+	return nil
+}
+
+// CountConfiguring returns a count of all rows in the configuring table with
+// the given host ID and profile ID.
+func CountConfiguring(hostID string, profileID string) (int, error) {
+	query := "SELECT COUNT(*) FROM configuring WHERE host_id = $1 AND profile_id = $2;"
+
+	stmt, err := preparedStatement(query)
+	if err != nil {
+		return -1, fmt.Errorf("cannot prepare SELECT: %w", err)
+	}
+
+	var count int
+	if err := stmt.Get(&count, hostID, profileID); err != nil {
+		return -1, fmt.Errorf("cannot execute SELECT: %w", err)
+	}
+
+	return count, nil
+}
+
+// DeleteConfiguring deletes all rows from the configuring table with the given
+// host ID and profile ID.
+func DeleteConfiguring(hostID string, profileID string) error {
+	stmt, err := preparedStatement(`DELETE FROM configuring WHERE host_id = $1 and profile_id = $2;`)
+	if err != nil {
+		return fmt.Errorf("cannot prepare DELETE: %w", err)
+	}
+
+	_, err = stmt.Exec(hostID, profileID)
+	if err != nil {
+		return fmt.Errorf("cannot execute DELETE: %w", err)
+	}
+
+	return nil
+}
+
 // Migrate inspects the current active migration version and runs all necessary
 // steps to migrate all the way up. If reset is true, everything is deleted in
 // the database before applying migrations.

--- a/internal/db/migrations/000007_create_table_configuring.down.sql
+++ b/internal/db/migrations/000007_create_table_configuring.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS configuring;

--- a/internal/db/migrations/000007_create_table_configuring.up.sql
+++ b/internal/db/migrations/000007_create_table_configuring.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS configuring (
+    host_id UUID NOT NULL,
+    profile_id UUID NOT NULL,
+    CONSTRAINT fk_profile_id FOREIGN KEY (profile_id) REFERENCES profiles(profile_id),
+    CONSTRAINT configuring_pkey PRIMARY KEY (host_id, profile_id)
+);


### PR DESCRIPTION
Add a 'configuring' table to the database. This table is inserted into
before the ApplyHost is initiated. If another host event is read off the
Kafka topic, the table first checked for the host ID; if a row exists
for the host ID and current profile ID, the ApplyHost routine is
skipped. When the dispatcherconsumer message reader reads a successful
message from playbook-dispatcher, it deletes the host ID/profile ID row
from the configuring table.