### PR TITLE
ci: let PR check only run read-only API tests

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -18,6 +18,7 @@ readonly IMAGE="quay.io/cloudservices/config-manager"
 # See ${CICD_ROOT}/cji_smoke_test.sh
 readonly IQE_CJI_TIMEOUT="10m"
 readonly IQE_PLUGINS="config-manager"
+readonly IQE_FILTER_EXPRESSION="test_ro"
 
 # Install bonfire into a venv and clone the bonfire repo. Export APP_ROOT, BONFIRE_ROOT, etc.
 source <(curl -s https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh)


### PR DESCRIPTION
With this change, the test runner should only execute `api_v1.test_ro` and `api_v2.test_ro`. See:

* Output of `pytest --help`, with focus on `-k` flag.
* https://github.com/RedHatInsights/cicd-tools/blob/main/cji_smoke_test.sh
* iqe-config-manager-plugin