### PR TITLE
ci: update golangci-lint timeout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.3.0
+        with:
+          version: latest
   lint-language:
     name: Lint language
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 2m


### PR DESCRIPTION
Set timeout to 2 minutes. Do it via config file.