### PR TITLE
revert: access AccountID unsafely

### DIFF
--- a/internal/cmd/inventoryconsumer/cmd.go
+++ b/internal/cmd/inventoryconsumer/cmd.go
@@ -99,12 +99,12 @@ func handler(ctx context.Context, msg kafka.Message) {
 			logger.Debug().Msg("profile missing org ID")
 			if config.DefaultConfig.TenantTranslatorHost != "" {
 				translator := tenantid.NewTranslator(config.DefaultConfig.TenantTranslatorHost)
-				orgID, err := translator.EANToOrgID(ctx, db.JSONNullStringSafeValue(profile.AccountID))
+				orgID, err := translator.EANToOrgID(ctx, profile.AccountID.String)
 				if err != nil {
 					logger.Error().Err(err).Msg("cannot translate EAN to orgID")
 					return
 				}
-				logger.Debug().Str("org_id", orgID).Str("account_number", db.JSONNullStringSafeValue(profile.AccountID)).Msg("translated EAN to orgID")
+				logger.Debug().Str("org_id", orgID).Str("account_number", profile.AccountID.String).Msg("translated EAN to orgID")
 				profile.OrgID.Valid = orgID != ""
 				profile.OrgID.String = orgID
 

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -45,7 +45,11 @@ func CopyProfile(from Profile) Profile {
 		ID:   uuid.New(),
 		Name: from.Name,
 		Label: func() *JSONNullString {
-			val := JSONNullStringSafeValue(from.AccountID) + "-" + uuid.New().String()
+			var val string
+			if from.AccountID != nil && from.AccountID.Valid {
+				val = from.AccountID.String + "-"
+			}
+			val = val + uuid.New().String()
 			return &JSONNullString{
 				NullString: sql.NullString{
 					Valid:  true,

--- a/internal/host.go
+++ b/internal/host.go
@@ -33,7 +33,7 @@ type Host struct {
 func ApplyProfile(ctx context.Context, profile *db.Profile, hosts []Host, fn func(resp []dispatcher.RunCreated)) {
 	logger := log.With().Logger()
 	if profile.AccountID != nil && profile.AccountID.Valid {
-		logger = logger.With().Str("account_id", db.JSONNullStringSafeValue(profile.AccountID)).Logger()
+		logger = logger.With().Str("account_id", profile.AccountID.String).Logger()
 	}
 	if profile.OrgID != nil && profile.OrgID.Valid {
 		logger = logger.With().Str("org_id", profile.OrgID.String).Logger()
@@ -55,7 +55,7 @@ func ApplyProfile(ctx context.Context, profile *db.Profile, hosts []Host, fn fun
 		logger.Debug().Str("client_id", host.SystemProfile.RHCID).Msg("creating run for host")
 		run := dispatcher.RunInput{
 			Recipient: host.SystemProfile.RHCID,
-			Account:   db.JSONNullStringSafeValue(profile.AccountID),
+			Account:   profile.AccountID.String,
 			Url:       config.DefaultConfig.PlaybookHost.String() + fmt.Sprintf(config.DefaultConfig.PlaybookPath, profile.ID),
 			Labels: &dispatcher.RunInput_Labels{
 				AdditionalProperties: map[string]string{

--- a/internal/http/v1/handlers.go
+++ b/internal/http/v1/handlers.go
@@ -87,7 +87,7 @@ func postStates(w http.ResponseWriter, r *http.Request) {
 
 	if equal {
 		resp := accountState{
-			Account:    db.JSONNullStringSafeValue(currentProfile.AccountID),
+			Account:    currentProfile.AccountID.String,
 			ApplyState: currentProfile.Active,
 			ID:         currentProfile.ID.String(),
 			Label:      currentProfile.Label.String,
@@ -142,7 +142,7 @@ func postStates(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	resp := accountState{
-		Account:    db.JSONNullStringSafeValue(newProfile.AccountID),
+		Account:    newProfile.AccountID.String,
 		ApplyState: newProfile.Active,
 		ID:         newProfile.ID.String(),
 		Label:      newProfile.Label.String,


### PR DESCRIPTION
Temporarily revert 8e8065e2455e5ab0244f5cdefdf753608040e61d to allow testing of the stale event logic.

Refs: 8e8065e2455e5ab0244f5cdefdf753608040e61d