### PR TITLE
feat: rebuild app image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
 COPY --chown=default . .
 ENV CGO_ENABLED=0
 RUN ["go", "build", "-o", "config_manager", "."]


### PR DESCRIPTION
W.r.t  CVE-2023-44487 & CVE-2023-39325, respective packages may not be used here.
Team has decided to update the dependencies just in case.