### PR TITLE
Fixes cloud-connector url

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -116,7 +116,7 @@ objects:
                     key: client-id
                     name: psk-cloud-connector
               - name: CM_CLOUD_CONNECTOR_HOST
-                value: ${CM_CLOUD_CONNECTOR_HOST}/api/cloud-connector/v2/
+                value: ${CM_CLOUD_CONNECTOR_HOST}/api/cloud-connector/
               - name: CM_INVENTORY_HOST
                 value: ${CM_INVENTORY_HOST}
               - name: CM_PLAYBOOK_HOST
@@ -183,7 +183,7 @@ objects:
                     key: client-id
                     name: psk-cloud-connector
               - name: CM_CLOUD_CONNECTOR_HOST
-                value: ${CM_CLOUD_CONNECTOR_HOST}/api/cloud-connector/v2/
+                value: ${CM_CLOUD_CONNECTOR_HOST}/api/cloud-connector/
               - name: CM_INVENTORY_HOST
                 value: ${CM_INVENTORY_HOST}
               - name: CM_PLAYBOOK_HOST
@@ -250,7 +250,7 @@ objects:
                     key: client-id
                     name: psk-cloud-connector
               - name: CM_CLOUD_CONNECTOR_HOST
-                value: ${CM_CLOUD_CONNECTOR_HOST}/api/cloud-connector/v2/
+                value: ${CM_CLOUD_CONNECTOR_HOST}/api/cloud-connector/
               - name: CM_PLAYBOOK_HOST
                 value: ${CM_PLAYBOOK_HOST}
               - name: CM_TENANT_TRANSLATOR_HOST


### PR DESCRIPTION
Getting below error in stage. 

```
{"level":"trace","http_client":"cloud-connector","method":"GET","url":"http://cloud-connector.cloud-connector-stage.svc.cluster.local:8080/api/cloud-connector/v2/v2/connections/5495e7b6-767a-4a96-a169-3c6937/status","headers":{"http_status":"Not Found","headers":{"Content-Length":["19"],"Content-Type":["text/plain; charset=utf-8"],"Date":["Tue, 19 Mar 2024 10:15:22 GMT"],"X-Content-Type-Options":["nosniff"]},"response":"404 page not found\n","time":"2024-03-19T10:15:22Z","caller":"/opt/app-root/src/infrastructure/persistence/cloudconnector/cloudconnector.go:119","message":"received HTTP response"}

{"level":"error","module":"inventory-consumer","offset":364160,"event_type":"updated","request_id":"7678ed7d-085d-40ee-9af4-201f4125e413","error":"unknown connection status: 404 Not Found: 404 page not found\n","time":"2024-03-19T10:15:22Z","caller":"/opt/app-root/src/internal/cmd/inventoryconsumer/cmd.go:137","message":"cannot get connection status from cloud-connector"}
```

We are getting this because auto generated code already has **v2** mentioned in the API - https://github.com/RedHatInsights/config-manager/blob/master/infrastructure/persistence/cloudconnector/cloudconnector.gen.go#L1043
