### PR TITLE
RHINENG-9025 add support to test playbook dispatcher run events in local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ mqtt_msg='{ "type": "connection-status", "message_id": "3a57b1ad-5163-47ee-9e57-
 send_mqtt_msg:
 	mqtt pub -V 3 -t redhat/insights/4b1efbbe-a447-48d0-98c3-3594aae1d2c5/control/out -h 127.0.0.1 -p 8883 -d -v -m ${mqtt_msg}
 
+send_run_event_msg:
+	kcat -b localhost:29092 -t platform.playbook-dispatcher.runs -H service=config_manager -P scripts/run-event.json
 
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
@@ -34,6 +36,9 @@ start-httpapi:
 		--log-level trace \
 		--metrics-port 9007 \
 		--inventory-host http://127.0.0.1:8001 \
+		--playbook-host https://random-host \
+		--dispatcher-psk=surajskey \
+		--dispatcher-host=http://127.0.0.1:8002 \
 		http-api
 
 start-inventory-consumer:
@@ -49,6 +54,11 @@ start-inventory-consumer:
 		--dispatcher-host=http://127.0.0.1:8002 \
 		inventory-consumer
 
+start-dispatcher-consumer:
+	go run main.go \
+		--kafka-brokers=localhost:29092 \
+		--metrics-port=9009 \
+		dispatcher-consumer
 
 configure-xjoin:
 	@./scripts/xjoin-config/configure-xjoin.sh

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -12,6 +12,7 @@ Before starting the development make sure below packages/binaries are installed 
 | mqtt cli                       | >=4.24.0 | https://hivemq.github.io/mqtt-cli/docs/installation/                           |
 | docker & docker-compose        | latest   | https://docs.docker.com/desktop/install/fedora/                                |
 | librdkafka &  librdkafka-devel | latest   | Use package-manager to install it.  dnf install -y librdkafka librdkafka-devel |
+| kcat (formaly kafkacat) | latest   | https://docs.confluent.io/platform/current/tools/kafkacat-usage.html |
 
 
 ## Clone the repository
@@ -44,9 +45,9 @@ docker ps | wc -l
 
 Now we are ready to start config-manager locally. 
 
-### Running config-manager locally. 
+### Running inventory-consumer locally. 
 
-Use the below make command to start inventory-consumer-service. 
+Use the below make command to start inventory-consumer service. 
 
 ```bash
 make start-inventory-consumer
@@ -59,6 +60,20 @@ make send_mqtt_msg
 Above command sends host-registration request to host-inventory and also send the connection status to cloud-connector service. 
 
 On the terminal where you ran `make start-inventory-consumer` you will see logs populating. At this point config-manager tries to setup the host by installing `rhc-worker-playbook` package and applies current org profile to the host.
+
+### Running dispatcher-consumer locally.
+Use the below make command to dispatcher-consumer service.
+
+```bash
+make start-dispatcher-consumer
+```
+
+### Sending data to local dispatcher-consumer. 
+```bash
+make send_run_event_msg
+```
+
+The above command sends a run event message to the `platform.playbook-dispatcher.runs` topic which is then consumed by our dispatcher-consumer service.
 
 ### Running config-manager API.
 

--- a/scripts/run-event.json
+++ b/scripts/run-event.json
@@ -1,0 +1,19 @@
+{
+    "event_type": "create",
+    "payload": {
+      "id": "4321",
+      "org_id": "10000",
+      "recipient": "4b1efbbe-a447-48d0-98c3-3594aae1d2c5",
+      "correlation_id": "fbf49ad9-ea79-41fb-9f6c-cb13307e993d",
+      "service": "config_manager",
+      "url": "http://random-host/api/config-manager/v1/states/1a1c1d-2a2b2c/playbook",
+      "labels": {
+        "id": "1234",
+        "state_id": "1a1c1d-2a2b2c"
+      },
+      "status": "success",
+      "timeout": 3600,
+      "created_at": "2024-03-27T11:15:45.429294Z",
+      "updated_at": "2024-03-27T11:15:45.429294Z"
+    }
+}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

To test our dispatcher-consumer service.

## Documentation update? :memo:

- [X] Yes
- [ ] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.