### PR TITLE
RHINENG-5011 playbook not getting dispatched with POST /profiles

### DIFF
--- a/infrastructure/persistence/inventory/inventory_repository.go
+++ b/infrastructure/persistence/inventory/inventory_repository.go
@@ -89,8 +89,16 @@ func (c *InventoryClient) GetInventoryClients(ctx context.Context, page int) (In
 	}
 	defer res.Body.Close()
 
-	err = json.NewDecoder(res.Body).Decode(&results)
-	if err != nil {
+	if res.StatusCode != http.StatusOK {
+		responseBody, err := io.ReadAll(res.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("Error reading response body")
+			return results, err
+		}
+		return results, fmt.Errorf("received non-200 status code: %d, response body: %s", res.StatusCode, string(responseBody))
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&results); err != nil {
 		body, _ := io.ReadAll(res.Body)
 		log.Error().Err(err).Msgf("error decoding inventory response: %v", string(body))
 	}

--- a/infrastructure/persistence/inventory/inventory_repository.go
+++ b/infrastructure/persistence/inventory/inventory_repository.go
@@ -89,13 +89,14 @@ func (c *InventoryClient) GetInventoryClients(ctx context.Context, page int) (In
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	switch {
+	case res.StatusCode >= 400:
 		responseBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			log.Error().Err(err).Msg("Error reading response body")
-			return results, err
+			return results, fmt.Errorf("error reading response body: %w", err)
 		}
-		return results, fmt.Errorf("received non-200 status code: %d, response body: %s", res.StatusCode, string(responseBody))
+		return results, fmt.Errorf("error response received: %v, response body: %v", res.StatusCode, string(responseBody))
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(&results); err != nil {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -7,31 +7,38 @@ import (
 	"config-manager/internal/db"
 	"context"
 
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/rs/zerolog/log"
 )
 
-var profiles chan db.Profile
+type ProfileWithIdentity struct {
+	Profile  db.Profile
+	Identity identity.XRHID
+}
+
+var profileIdentityChan chan ProfileWithIdentity
 
 func init() {
-	profiles = make(chan db.Profile)
+	profileIdentityChan = make(chan ProfileWithIdentity)
 	go func() {
-		for p := range profiles {
-			hosts, err := inventory.NewInventoryClient().GetAllInventoryClients(context.Background())
+		for profileIdentity := range profileIdentityChan {
+			ctx := context.WithValue(context.Background(), identity.Key, profileIdentity.Identity)
+			hosts, err := inventory.NewInventoryClient().GetAllInventoryClients(ctx)
 			if err != nil {
 				log.Error().Err(err).Msg("cannot get hosts from inventory")
 				continue
 			}
 
-			internal.ApplyProfile(context.Background(), &p, hosts, func(resp []dispatcher.RunCreated) {
-				log.Info().Str("profile_id", p.ID.String()).Msg("applied profile")
+			internal.ApplyProfile(ctx, &profileIdentity.Profile, hosts, func(resp []dispatcher.RunCreated) {
+				log.Info().Str("profile_id", profileIdentity.Profile.ID.String()).Msg("applied profile")
 			})
 		}
 	}()
 }
 
-// Dispatch queues the profile on a channel to be dispatched to connected hosts.
-func Dispatch(p db.Profile) {
+// Dispatch queues the profile with identity on a channel to be dispatched to connected hosts.
+func Dispatch(profile db.Profile, identity identity.XRHID) {
 	go func() {
-		profiles <- p
+		profileIdentityChan <- ProfileWithIdentity{Profile: profile, Identity: identity}
 	}()
 }

--- a/internal/http/v2/handlers.go
+++ b/internal/http/v2/handlers.go
@@ -182,8 +182,7 @@ func createProfile(w http.ResponseWriter, r *http.Request) {
 		render.RenderPlain(w, r, http.StatusInternalServerError, fmt.Sprintf("cannot insert new profile: %v", err), logger)
 		return
 	}
-
-	dispatch.Dispatch(newProfile)
+	dispatch.Dispatch(newProfile, identity.Get(r.Context()))
 
 	render.RenderJSON(w, r, http.StatusCreated, newProfile, logger)
 }


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Playbook was not getting dispatched on requesting POST /profiles. This was mainly because we are currently getting `401 Unauthorized` Status in the [response](https://github.com/RedHatInsights/config-manager/blob/master/infrastructure/persistence/inventory/inventory_repository.go#L85) due to missing `X-Rh-Identity` field in context.Context - we are sending [context.Background()](https://github.com/RedHatInsights/config-manager/blob/master/internal/dispatch/dispatch.go#L19) and we don't get any error i.e. the request was successfully sent, but the server responded with a 401 Unauthorized status. Due to this, it goes to [ApplyProfile](https://github.com/RedHatInsights/config-manager/blob/master/internal/dispatch/dispatch.go#L25) function with no hosts where it doesn't fall into any code block. Hence, nothing happens.

Logs without fix
```
{"level":"debug","org_id":"0002","num_hosts":0,"timestamp":"2024-03-27T18:10:59.534168816+05:30","caller":"/home/rohinichandra/Rohini/config-manager/internal/host.go:46","message":"applying profile for hosts"}
```

Below are the logs with the fix when identity header is provided.
```
{"level":"debug","org_id":"0002","num_hosts":1,"timestamp":"2024-03-27T18:11:27.314342855+05:30","caller":"/home/rohinichandra/Rohini/config-manager/internal/host.go:46","message":"applying profile for hosts"}
{"level":"debug","org_id":"0002","client_id":"4b1efbbe-a447-48d0-98c3-3594aae1d2c5","timestamp":"2024-03-27T18:11:27.314353851+05:30","caller":"/home/rohinichandra/Rohini/config-manager/internal/host.go:54","message":"creating run for host"}
{"level":"debug","start":0,"end+1":1,"timestamp":"2024-03-27T18:11:27.314367885+05:30","caller":"/home/rohinichandra/Rohini/config-manager/internal/host.go:76","message":"batching runs"}
{"level":"debug","http_client":"playbook-dispatcher","http_status":"207 Multi-Status","timestamp":"2024-03-27T18:11:27.319437834+05:30","caller":"/home/rohinichandra/Rohini/config-manager/infrastructure/persistence/dispatcher/dispatcher.go:78","message":"received response from playbook-dispatcher"}
{"level":"debug","http_client":"playbook-dispatcher","runs_created":[{"code":201,"id":"6845182c-880c-4a7d-8664-064fcf321615"}],"timestamp":"2024-03-27T18:11:27.319466795+05:30","caller":"/home/rohinichandra/Rohini/config-manager/infrastructure/persistence/dispatcher/dispatcher.go:85","message":"runs created"}
{"level":"trace","org_id":"0002","runs_created":[{"code":201,"id":"6845182c-880c-4a7d-8664-064fcf321615"}],"timestamp":"2024-03-27T18:11:27.319475304+05:30","caller":"/home/rohinichandra/Rohini/config-manager/internal/host.go:83","message":"dispatched work to playbook-dispatcher"}
{"level":"info","profile_id":"eaad1e5c-4b60-475b-adb0-1b1210a05d9c","timestamp":"2024-03-27T18:11:27.319481669+05:30","caller":"/home/rohinichandra/Rohini/config-manager/internal/dispatch/dispatch.go:33","message":"applied profile"}
```

Below are the logs with the fix when identity header is not provided.

```
{"level":"error","error":"unable to get inventory clients: received non-200 status code: 401, response body: {\n  \"detail\": \"No authorization token provided\",\n  \"status\": 401,\n  \"title\": \"Unauthorized\",\n  \"type\": \"about:blank\"\n}\n","timestamp":"2024-03-27T18:42:19.226713932+05:30","caller":"/home/rohinichandra/Rohini/config-manager/internal/dispatch/dispatch.go:28","message":"cannot get hosts from inventory"}
```

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.