### PR TITLE
RHINENG-9142 Playbook tasks reorder on requesting GET /playbooks

### DIFF
--- a/internal/playbook.go
+++ b/internal/playbook.go
@@ -29,6 +29,8 @@ func GeneratePlaybook(state map[string]string) (string, error) {
 	sort.SliceStable(keys, func(i, j int) bool {
 		if keys[i] == "insights" {
 			return true
+		} else if keys[j] == "insights" {
+			return false
 		}
 		return keys[i] < keys[j]
 	})


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Playbook tasks are being reordered every time we request GET /playbooks. The `Insights` playbook should be the first to be executed then the other services.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.