### PR TITLE
RHINENG-8793 Use /playbooks endpoint to get a playbook for a host

### DIFF
--- a/infrastructure/persistence/dispatcher/dispatcher_test.go
+++ b/infrastructure/persistence/dispatcher/dispatcher_test.go
@@ -32,7 +32,7 @@ func TestDispatch(t *testing.T) {
 						Recipient: uuid.MustParse("276c4685-fdfb-4172-930f-4148b8340c2e"),
 						OrgId:     "0000001",
 						Principal: "test_user",
-						Url:       "https://cloud.redhat.com/api/config-manager/v1/states/e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
+						Url:       "https://cloud.redhat.com/api/config-manager/v2/playbooks?profile_id=e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
 						Name:      "Apply fix",
 						Labels: &Labels{
 							"test": "e417581a-d649-4cdc-9506-6eb7fdbfd66d",
@@ -42,7 +42,7 @@ func TestDispatch(t *testing.T) {
 						Recipient: uuid.MustParse("9a76b28b-0e09-41c8-bf01-79d1bef72646"),
 						OrgId:     "0000001",
 						Principal: "test_user",
-						Url:       "https://cloud.redhat.com/api/config-manager/v1/states/e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
+						Url:       "https://cloud.redhat.com/api/config-manager/v2/playbooks?profile_id=e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
 						Name:      "Apply fix",
 						Labels: &Labels{
 							"test": "e417581a-d649-4cdc-9506-6eb7fdbfd66d",
@@ -73,7 +73,7 @@ func TestDispatch(t *testing.T) {
 						Recipient: uuid.MustParse("276c4685-fdfb-4172-930f-4148b8340c2e"),
 						OrgId:     "0000001",
 						Principal: "test_user",
-						Url:       "https://cloud.redhat.com/api/config-manager/v1/states/e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
+						Url:       "https://cloud.redhat.com/api/config-manager/v2/playbooks?profile_id=e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
 						Name:      "Apply Fix",
 						Labels: &Labels{
 							"test": "e417581a-d649-4cdc-9506-6eb7fdbfd66d",
@@ -83,7 +83,7 @@ func TestDispatch(t *testing.T) {
 						Recipient: uuid.MustParse("9a76b28b-0e09-41c8-bf01-79d1bef72646"),
 						OrgId:     "0000001",
 						Principal: "test_user",
-						Url:       "https://cloud.redhat.com/api/config-manager/v1/states/e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
+						Url:       "https://cloud.redhat.com/api/config-manager/v2/playbooks?profile_id=e417581a-d649-4cdc-9506-6eb7fdbfd66d/playbook",
 						Name:      "Apply Fix",
 						Labels: &Labels{
 							"test": "e417581a-d649-4cdc-9506-6eb7fdbfd66d",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,7 +115,7 @@ var DefaultConfig Config = Config{
 	Modules:              flagvar.EnumSetCSV{Choices: []string{"http-api", "dispatcher-consumer", "inventory-consumer"}, Value: map[string]bool{}},
 	PlaybookFiles:        "./playbooks/",
 	PlaybookHost:         flagvar.URL{Value: url.MustParse("https://cert.cloud.stage.redhat.com")},
-	PlaybookPath:         "/api/config-manager/v1/states/%v/playbook",
+	PlaybookPath:         "/api/config-manager/v2/playbooks?%v",
 	ServiceConfig:        `{"insights":"enabled","compliance_openscap":"enabled","remediations":"enabled"}`,
 	StaleEventDuration:   24 * time.Hour,
 	TenantTranslatorHost: "",

--- a/internal/http/v2/handlers_test.go
+++ b/internal/http/v2/handlers_test.go
@@ -2,7 +2,9 @@ package v2
 
 import (
 	"bytes"
+	"config-manager/internal/config"
 	"config-manager/internal/db"
+	"config-manager/internal/util"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -321,6 +323,133 @@ func TestCreateProfile(t *testing.T) {
 
 			if !cmp.Equal(got, test.want, cmp.AllowUnexported(response{}), cmpopts.IgnoreMapEntries(test.ignoreMapEntries)) {
 				t.Errorf("%v", cmp.Diff(got, test.want, cmp.AllowUnexported(response{})))
+			}
+		})
+	}
+}
+
+func TestPlaybooks(t *testing.T) {
+	config.DefaultConfig.PlaybookFiles = "../../../playbooks/"
+
+	tests := []struct {
+		description string
+		seed        []byte
+		input       request
+		want        string
+	}{
+		{
+			description: "get playbook by profile_id",
+			seed:        []byte(`INSERT INTO profiles (profile_id, account_id, org_id, created_at, insights, remediations, compliance) VALUES ('b5db9cbc-4ecd-464b-b416-3a6cd67af87a', '10064', '78606', '` + UNIXTime + `', FALSE, FALSE, FALSE);`),
+			input: request{
+				method: http.MethodGet,
+				url:    "/playbooks?profile_id=b5db9cbc-4ecd-464b-b416-3a6cd67af87a",
+				headers: map[string]string{
+					"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{"identity":{"account_number":"10064","auth_type":"basic","employee_account_number":"10064","internal":{"org_id":"78606"},"org_id":"78606","type":"User","user":{"email":"collett@elfreda.name","first_name":"Maricela","is_active":true,"is_internal":false,"is_org_admin":true,"last_name":"Purdy","locale":"pa","user_id":"algae","username":"torque"}}}`)),
+				},
+			},
+			want: `---
+				# Service Enablement playbook
+
+				# This playbook will take care of all steps required to disable
+				# Insights Client
+				- name: Insights Disable
+				  hosts: localhost
+				  become: yes
+				  vars:
+						insights_signature_exclude: /hosts,/vars/insights_signature
+						insights_signature: !!binary |
+						TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+						RWNnZGpFS0NtbFJTVlpCZDFWQldVODNjekU0ZG5jMU9FUXJhalZ3VGtGUmFGcGlhRUZCYkdkdGFI
+						WXpZVTR5WjFJM2EwRXdiRVZMSzNNeVVVeGtiSE00YkhSaVZXZ0tORkZoWlZaSVNWa3pPRTVsTXpG
+						aFJUTkRURFJZV0ZneVVuSlhUbk5QVG5GbFZFUmpPV2xOVERjM05uZzFjbTE2VWk5bFVrbG5NbXg1
+						UVRoQkwwOWpOd3A0ZGtkcE1uaHBSRkZVWWtsVE9XaFRTM04yZEZKVllXbHdWWEIwUkV0TVlVcHZN
+						VTl2Ulhkd2JqQXhUVGMyZDJOQlZqSmxUR1Y0YkhweU5TOXpOazlMQ25oRU4waFFiMjlpU0RGblVG
+						QjNVbmszZDFadVdIUXhSbE5DYVVKUlYzcE9XRGRzU0hOR1RUaHVjbE01UlhaMWJ6VjBTMmh6Y1Zo
+						U2VqQnNXR0prWVZnS1NVeERiVWhMVkdjd2JESm9iRTA1V25sS1JqTllNRUpLWVV0dFRWRjFibVpL
+						Wkd0NlMxSlpOR2QyUTBaTFZGbHBWMEZxZDNFelRreFNTMmQ0Wlhwd1VBcDVlV2xVVTBoRlRrTlZP
+						RXB2V0Rsa1FuWm5UbUl5TWpreFZIUmxSbGRSVTFGcVlUazRLeXQ2VGpKV2JqVlFNbmN5TlZFd2Iw
+						ZzBNRGs1Ym5kclVEazJDakptVHk5aVJpOTFTM0l4V1RBelFsSmhaRFEwWmxneGVFYzNlbXBVYUZw
+						WmNYUjFUM2hyUkVKVk5USkpTRlpaYWxVMFNsVmpPWFUzYUdOTFRYRlNhSG9LVVdKc1EwSnVNMDV2
+						YUVsbWEySjFNSGxqVldwQldIcHVOR3hJVTJaNFFreHFOM3BYUVU4MWEwTnNVbm8xVTJScWFIVnFk
+						bUl3Tms4MlJIRkZWU3MzWkFwVWVVSTRVVXd4Y1VRclp5dFFSV3d2U0RVclZtTm1NRlJST0dnd05G
+						bHBiVUpOYWpkWVFuQkxVSFpWTlc1WlJVRmtiMVIxWkUwMlpWSk1aRUl2VG5aakNtZExXV1pJTm1G
+						eGNFMXRiVTFVUTFwTVRFZENLM05yY1ZwdFFVSlJTazV5VlcxM2NYRnlSakJYVVZGMk9HSkxZMFpp
+						Tm1kb0swbzBlalJLVW5nM1dqWUtkVU5GV2tsRlFVWnRSbkkwTDNjcmJ6QndaM1ZJYlZCRVZrNUZZ
+						WGhTVWpWMlNFSm9Xa2xRV25wNlUwNXRhMDAwWTNWblZHbDZUM0JMVUhoTVRYWlJTZ3A0U0ZCUFZq
+						SjFXRUZXTkQwS1BWQkphRThLTFMwdExTMUZUa1FnVUVkUUlGTkpSMDVCVkZWU1JTMHRMUzB0Q2c9
+						PQ==   
+				  tasks:
+					- name: Disable the insights-client
+					  command: insights-client --disable-schedule
+
+				# This playbook will perform steps required to remove Insights Compliance service from your system.
+				- name: Compliance OpenSCAP Remove
+				  hosts: localhost
+				  become: yes
+				  vars:
+					insights_signature_exclude: /hosts,/vars/insights_signature
+					insights_signature: !!binary |
+					TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+					RWNnZGpFS0NtbFJTVlpCZDFWQldVbENSa2c0ZG5jMU9FUXJhalZ3VGtGUmFuSXlRUzhyU3pOa1kw
+					dGtUVkZpYTNVellWRmFVV1UzY0VSWVdVdEdabXhsU1M5dlFra0tWR1lyZURkYVkyNUpaMk5WWjBo
+					MlpWWlRiVFpvVWtzM2QycDZhWGxGV0RGTlZHUTFPVGhTYUhaU2VGRjZVMUZvTVd0V1EzQkROWG94
+					SzBob2FXTkxjd3B4TjFGV2RXZ3lNWFpFVm10TGRIazNSemhKZVhKT2J6UnlXbTl4ZG5kSWJUaDNh
+					VFJVV0RKTVNFcDRhM0JaSzBGSldFMVVPR1JXZEU1VGQySXZRekYwQ2tFek1sUjNMMmx2Y0hONlpq
+					SkdOWGxsZWpWcU9YbEZaa0ZGSzNocE9YWnZjMlpFZFV4blRXWjVUVVV6UjJZeVdYRm1OVFpETVZa
+					NlJUWmthVU4wWm00S2JsQjZTR2xOUW1kTVVVZHpORmR4V0VwUGVrc3dZbU4zZW5VNVdUTXdZVXhQ
+					VUZneWNHWm9hMEpQWW5wbGRDOXBOR2RhTTBoNmRWTkJRamxaYmpOYUx3cEJaa2xSZW5OQ2JrMUNV
+					a05LYTNOeVJrZzVPV0V5YzAwdlVIUXJaR2hMZW01Q1lXOUpRbGhwY25GMFF6aEVNbEpHUVROdFpY
+					bzBPVlpyVjB4V1drUkhDalZQTTBrMFNXMDNSVGMyYkdGaUsxWk5jbmRQTVV4S2NrVnRNazFGVWtK
+					aFRrWm1ObGhSV0ZkVlpqQTVURXBRYmpSd2NXd3diRTgwYjNORE1sWkJkVGtLVHpOcGFuaDNWVEJ2
+					YTA1dGJsUm5hVFpqTTFBNGRubEtNbTVvTkRscFQzbHJhRmxRY0ROa1ExVmlZMGRCTDBsM1UzSnFk
+					MmRZSzFSck9ISmpMMDVuV1FwTmVVUlNRalZtWlc1UGFrdElPRVp1V2tvM1VXY3dWekUzUzI5WVox
+					VjBaa2w2WmxORFZqTnpiMVJ3TVVKcVZ6STVURWhyWlV4dVZIbDFZbTVCVlRCc0NtVnlPRmhoV2s5
+					RmVTOXpZbmhPVEZKSWVVb3ZUMkpWUVc5NlQzcGFORUZzVmswMk0zUTNVbUZzTTJvMlkyMW1VbXhD
+					VlhSQlJsaDNjVFpDYWpSQ2JYUUtSV1ZpY1N0UFl6aDZZM3BIZEVaNU55dHJSa1F6V0VKbGJubFJW
+					emxrTWk4eU9XWkdNVzF2VmxsVVRXazRiQzlLYVZKU1ZtSlJUelI0TWtwMmVWUTNTQXBMVTBwUlRE
+					SnZUMnc1T0QwS1BXcEpaa3dLTFMwdExTMUZUa1FnVUVkUUlGTkpSMDVCVkZWU1JTMHRMUzB0Q2c9
+					PQ==
+				  tasks:
+					- name: Compliance OpenSCAP disabled
+					debug:
+						msg: "Compliance OpenSCAP is not enabled. Nothing to do"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if err := db.Open("pgx", DSN); err != nil {
+				t.Fatalf("failed to open database: %v", err)
+			}
+			defer func() {
+				if err := db.Close(); err != nil {
+					t.Fatalf("failed to close database: %v", err)
+				}
+			}()
+
+			if err := db.Migrate(true); err != nil {
+				t.Fatalf("failed to migrate database: %v", err)
+			}
+
+			if err := db.SeedData(test.seed); err != nil {
+				t.Fatalf("failed to seed database: %v", err)
+			}
+
+			req := httptest.NewRequest(test.input.method, test.input.url, nil)
+			for k, v := range test.input.headers {
+				req.Header.Add(k, v)
+			}
+			rr := httptest.NewRecorder()
+
+			router := chi.NewMux()
+			router.Use(identity.EnforceIdentity)
+			router.Get("/playbooks", getPlaybook)
+			router.ServeHTTP(rr, req)
+
+			got := util.NormalizeWhitespace(rr.Body.String())
+			test.want = util.NormalizeWhitespace(test.want)
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("%v", cmp.Diff(got, test.want))
 			}
 		})
 	}

--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"strings"
+)
+
+// NormalizeWhitespace removes extra whitespace characters from a string,
+// replacing them with a single space, and trims leading and trailing whitespace.
+func NormalizeWhitespace(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.TrimSpace(s)
+	return s
+}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Dependent services are now using the `v2` API of Config Manager. But we are sending a playbook URL with `v1` to Playbook Dispatcher. With this change, we will use the `v2/playbooks` endpoint instead of `v1/states/{id}/playbook` while sending this URL to Playbook Dispatcher to get a playbook of the given profile to configure a host.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [X] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.