### PR TITLE
add profile_id param to /v2/playbooks endpoint

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,7 +115,7 @@ var DefaultConfig Config = Config{
 	Modules:              flagvar.EnumSetCSV{Choices: []string{"http-api", "dispatcher-consumer", "inventory-consumer"}, Value: map[string]bool{}},
 	PlaybookFiles:        "./playbooks/",
 	PlaybookHost:         flagvar.URL{Value: url.MustParse("https://cert.cloud.stage.redhat.com")},
-	PlaybookPath:         "/api/config-manager/v2/playbooks?%v",
+	PlaybookPath:         "/api/config-manager/v2/playbooks?profile_id=%v",
 	ServiceConfig:        `{"insights":"enabled","compliance_openscap":"enabled","remediations":"enabled"}`,
 	StaleEventDuration:   24 * time.Hour,
 	TenantTranslatorHost: "",


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Include `profile_id` param to v2/playbooks endpoint.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.