### PR TITLE
RHINENG-9355 RHCID should be used when calling GetConnectionStatus

### DIFF
--- a/internal/cmd/inventoryconsumer/cmd.go
+++ b/internal/cmd/inventoryconsumer/cmd.go
@@ -132,7 +132,7 @@ func handler(ctx context.Context, msg kafka.Message) {
 				return
 			}
 
-			status, dispatchers, err := client.GetConnectionStatus(ctx, event.Host.OrgID, event.Host.SubscriptionManagerID)
+			status, dispatchers, err := client.GetConnectionStatus(ctx, event.Host.OrgID, event.Host.SystemProfile.RHCID)
 			if err != nil {
 				logger.Error().Err(err).Msg("cannot get connection status from cloud-connector")
 				return


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Even though `RHCID` is the same as the `SubscriptionManagerID`, all (or most) hosts will have a SubscriptionManagerID even if they do not have a connection to Cloud Connector which can cause issues while getting connection status.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.