### PR TITLE
RHINENG-9694 Remove KafkaCAPath check

### DIFF
--- a/internal/util/kafka.go
+++ b/internal/util/kafka.go
@@ -24,16 +24,12 @@ type kafkautil struct{}
 func (k kafkautil) NewReader(topic string) *kafka.Reader {
 	var dialer *kafka.Dialer
 
-	if config.DefaultConfig.KafkaCAPath != "" {
-		saslMechanism, tlsConfig := getSaslAndTLSConfig()
-		dialer = &kafka.Dialer{
-			Timeout:   10 * time.Second,
-			DualStack: true,
-			TLS:       tlsConfig,
-		}
-		if config.DefaultConfig.KafkaUsername != "" && config.DefaultConfig.KafkaPassword != "" {
-			dialer.SASLMechanism = saslMechanism
-		}
+	saslMechanism, tlsConfig := getSaslAndTLSConfig()
+	dialer = &kafka.Dialer{
+		Timeout:       10 * time.Second,
+		DualStack:     true,
+		TLS:           tlsConfig,
+		SASLMechanism: saslMechanism,
 	}
 
 	return kafka.NewReader(kafka.ReaderConfig{
@@ -47,17 +43,11 @@ func (k kafkautil) NewReader(topic string) *kafka.Reader {
 
 // NewWriter creates a configured kafka.Writer.
 func (k kafkautil) NewWriter(topic string) *kafka.Writer {
-	var transport *kafka.Transport = kafka.DefaultTransport.(*kafka.Transport)
 
-	if config.DefaultConfig.KafkaCAPath != "" {
-		saslMechanism, tlsConfig := getSaslAndTLSConfig()
-
-		transport = &kafka.Transport{
-			TLS: tlsConfig,
-		}
-		if config.DefaultConfig.KafkaUsername != "" && config.DefaultConfig.KafkaPassword != "" {
-			transport.SASL = saslMechanism
-		}
+	saslMechanism, tlsConfig := getSaslAndTLSConfig()
+	transport := &kafka.Transport{
+		TLS:  tlsConfig,
+		SASL: saslMechanism,
 	}
 
 	return &kafka.Writer{


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Facing this in Stage as empty Kafka CA cert testing was done in Stage yesterday. The current code checks if `KafkaCAPath` is there and then only configures Kafka reader and writer. 
```
{"level":"error","error":"fetching message: EOF","time":"2024-04-25T07:48:47Z","caller":"/opt/app-root/src/internal/cmd/dispatcherconsumer/cmd.go:28","message":"unable to read message"}
{"level":"error","error":"fetching message: EOF","time":"2024-04-25T07:49:02Z","caller":"/opt/app-root/src/internal/cmd/dispatcherconsumer/cmd.go:28","message":"unable to read message"}
{"level":"error","error":"fetching message: EOF","time":"2024-04-25T07:49:17Z","caller":"/opt/app-root/src/internal/cmd/dispatcherconsumer/cmd.go:28","message":"unable to read message"}

```

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.