### PR TITLE
Ref-RHINENG-9596 Modify sensitiveField

### DIFF
--- a/infrastructure/persistence/cloudconnector/cloudconnector.go
+++ b/infrastructure/persistence/cloudconnector/cloudconnector.go
@@ -75,7 +75,7 @@ func (c *cloudConnectorClientImpl) SendMessage(ctx context.Context, orgID string
 	resp, err := c.PostV2ConnectionsClientIdMessageWithBody(ctx, recipient, "application/json", bytes.NewReader(data), func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("x-rh-cloud-connector-org-id", orgID)
 
-		sensitiveField := "x-rh-cloud-connector-psk"
+		sensitiveField := "X-Rh-Cloud-Connector-Psk"
 		filteredHeaders := make(http.Header)
 		for key, values := range req.Header {
 			if key != sensitiveField {


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Updating `x-rh-cloud-connector-psk` to `X-Rh-Cloud-Connector-Psk` while excluding it from logs as I noticed in the logs that the latter is being used even though we have the former one in the code.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [X] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.