### PR TITLE
RHINENG-9640 Remove unnecessary columns from the Profiles table

### DIFF
--- a/internal/db/migrations/000007_remove_unwanted_columns.down.sql
+++ b/internal/db/migrations/000007_remove_unwanted_columns.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN label TEXT, ADD COLUMN name TEXT, ADD COLUMN creator TEXT;

--- a/internal/db/migrations/000007_remove_unwanted_columns.up.sql
+++ b/internal/db/migrations/000007_remove_unwanted_columns.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles DROP COLUMN label, DROP COLUMN name, DROP COLUMN creator;


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Remove `label`, `name`, and `creator` columns from the `profiles` table. These are not used anywhere in our codebase or by dependent services.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [X] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [X] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.