### PR TITLE
RHINENG-9923 API v1 POST calls produce HTTP 504 responses

### DIFF
--- a/internal/http/v1/handlers_test.go
+++ b/internal/http/v1/handlers_test.go
@@ -160,7 +160,7 @@ func TestPostStates(t *testing.T) {
 				},
 			},
 			want: response{
-				code: http.StatusOK,
+				code: http.StatusCreated,
 				body: map[string]interface{}{
 					"account":     "10064",
 					"apply_state": false,


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Getting 504 status code. Even though a resource is created (`newProfile`), the service may be experiencing delays in retrieving inventory clients from an external service. Therefore, it could result in timeouts.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.