### PR TITLE
RHINENG-10326 set replica pod count to 3

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -326,7 +326,7 @@ parameters:
     value: 512Mi
 
   - name: REPLICAS
-    value: "2"
+    value: "3"
 
   - name: CM_DISPATCHER_HOST
     required: true


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

As a part of the onboarding process, the deployment must have replicas >= 3.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.