### PR TITLE
RHINENG-12143 update Cloud Connector component

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -29,7 +29,7 @@ objects:
       envName: ${ENV_NAME}
 
       optionalDependencies:
-        - cloud-connector-api
+        - cloud-connector
         - playbook-dispatcher
         - host-inventory
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -28,8 +28,7 @@ source "${CICD_ROOT}/build.sh"
 
 EXTRA_DEPLOY_ARGS=""
 
-# Include cloud-connector (not just cloud-connector-api) as a deployment
-# argument. This pulls in the 'cloud-connector' resource, which in turn pulls in
+# This pulls in the 'cloud-connector' resource, which in turn pulls in
 # the mosquitto service we need to stand up a live environment.
 EXTRA_DEPLOY_ARGS="${EXTRA_DEPLOY_ARGS} cloud-connector"
 

--- a/scripts/bonfire.yml
+++ b/scripts/bonfire.yml
@@ -15,7 +15,7 @@ apps:
           TENANT_TRANSLATOR_IMPL: mock
   - name: cloud-connector
     components:
-      - name: cloud-connector-api
+      - name: cloud-connector
         host: github
         repo: RedHatInsights/cloud-connector
         path: deploy/clowdapp.yml

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -231,7 +231,7 @@ services:
       - db-cloud-connector
       - kafka-create-topics
       - mqtt-consumer
-  cloud-connector-api:
+  cloud-connector:
     image: quay.io/cloudservices/cloud-connector
     ports:
       - "8084:8081"
@@ -342,7 +342,7 @@ services:
       - 8002:8000
     environment:
       - CLOUD_CONNECTOR_IMPL=impl
-      - CLOUD_CONNECTOR_HOST=cloud-connector-api
+      - CLOUD_CONNECTOR_HOST=cloud-connector
       - CLOUD_CONNECTOR_PORT=8081
       - CLOUD_CONNECTOR_CLIENT_ID=suraj
       - CLOUD_CONNECTOR_PSK=surajskey
@@ -355,5 +355,5 @@ services:
       - DB_PASSWORD=insights
     depends_on:
       - playbook-dispatcher-db
-      - cloud-connector-api
+      - cloud-connector
       - dispatcher-connector


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Recently, Cloud Connector has updated its component name from `cloud-connector-api` to `cloud-connector`. We need to update it on our end as well.

Reference - [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/113709)

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [X] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.