### PR TITLE
RHINENG-12161 Fix rand.Seed

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -27,8 +27,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
-	port = uint32(rand.Int31n(10000-9876) + 9876)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	port = uint32(r.Int31n(10000-9876) + 9876)
 	DSN = fmt.Sprintf("host=localhost port=%v user=postgres password=postgres dbname=postgres sslmode=disable", port)
 
 	runtimedir, err := os.MkdirTemp("", "config-manager-internal-db.")

--- a/internal/http/v2/handlers_test.go
+++ b/internal/http/v2/handlers_test.go
@@ -44,8 +44,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
-	port = uint32(rand.Int31n(10000-9876) + 9876)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	port = uint32(r.Int31n(10000-9876) + 9876)
 	DSN = fmt.Sprintf("host=localhost port=%v user=postgres password=postgres dbname=postgres sslmode=disable", port)
 
 	runtimedir, err := os.MkdirTemp("", "config-manager-internal-http-v2.")


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

`rand.Seed()` has been deprecated since Go 1.20. The recommended approach now is to create a new random generator instance using `rand.New(rand.NewSource(seed))` if you need a specific sequence or use `rand.NewSource(seed)` directly for generating random numbers without modifying the global generator.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [X] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.