### PR TITLE
RHINENG-12231 update quay repo reference to use new Konflux image

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -311,7 +311,7 @@ parameters:
   - name: IMAGE_TAG
     required: true
   - name: IMAGE
-    value: quay.io/cloudservices/config-manager
+    value: quay.io/rhc-manager-ros-tenant/config-manager-master/config-manager-master
   - description: ClowdEnvironment name
     name: ENV_NAME
     required: true


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Use the new image created by Konflux.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [X] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.