### PR TITLE
RHINENG-12621 configure Renovate to batch Konflux changes to a particular day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+    "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+    "schedule": ["on sunday"],
+    "timezone": "Asia/Kolkata"
+ }


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Konflux will send PRs every time something is updated - if we don't want these showing up randomly, we can actually configure this to batch changes!

## Documentation update? :memo:

- [ ] Yes
- [X] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.