### PR TITLE
Migrate from UBI8 to UBI9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
 COPY --chown=default . .
 ENV CGO_ENABLED=0
 RUN ["go", "build", "-o", "config_manager", "."]
 
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 COPY ./playbooks ./playbooks
 COPY --from=builder /opt/app-root/src/config_manager .
 ENTRYPOINT ["./config_manager"]


### PR DESCRIPTION
## PR Title :boom:

Migrate to UBI9 image. Jira card for this activity is RHINENG-12540.
I tested building of the image locally with:
```
podman build . -f ./Dockerfile -t test_build_config_manager
```

## Why do we need this change? :thought_balloon:

We need to migrate to newer image - UBI9.

## Documentation update? :memo:

- [ ] Yes
- [ x] No
