### PR TITLE
Revert "Migrate from UBI8 to UBI9"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
 COPY --chown=default . .
 ENV CGO_ENABLED=0
 RUN ["go", "build", "-o", "config_manager", "."]
 
-FROM registry.access.redhat.com/ubi9-minimal:latest
+FROM registry.access.redhat.com/ubi8-minimal:latest
 COPY ./playbooks ./playbooks
 COPY --from=builder /opt/app-root/src/config_manager .
 ENTRYPOINT ["./config_manager"]


### PR DESCRIPTION
Reverts RedHatInsights/config-manager#202

Please merge only when Konflux supports UBI8 (28th of Oct?).

RHINENG-13905