### PR TITLE
make it possible to override the db port in docker-compose.yml

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       POSTGRES_USER: insights
       POSTGRES_DB: insights
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
 
   db-host-inventory:
     image: debezium/postgres:15-alpine


### PR DESCRIPTION
## make it possible to override the db port in docker-compose.yml

related to https://issues.redhat.com/browse/RHINENG-16029

## Why do we need this change? :thought_balloon:

helps to avoid conflicts e.g. when running alongside kessel

## Documentation update? :memo:

- [ ] Yes
- [x] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added