### PR TITLE
[RHCLOUD-49129] Fetch default ws bypassing permission check

### DIFF
--- a/internal/http/middleware/authorization/rbac.go
+++ b/internal/http/middleware/authorization/rbac.go
@@ -42,7 +42,7 @@ type response struct {
 // - configurable timeout
 func (a *rbacClient) GetDefaultWorkspaceID(context context.Context, orgID string) (string, error) {
 
-	url := fmt.Sprintf("%s/api/rbac/v2/workspaces/?type=default", a.baseURL)
+	url := fmt.Sprintf("%s/api/rbac/v2/workspaces/?type=default&with_ancestry=true", a.baseURL)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
## PR Title :boom:
https://redhat.atlassian.net/browse/RHCLOUD-49129: Add with_ancestry query parameter to workspace list endpoint

## Why do we need this change? :thought_balloon:

RBAC require explicit parameter to bypass the permission check when fetching default workspace

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## :guardsman: Checklist :dart:

- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.